### PR TITLE
Add file list table

### DIFF
--- a/file_list.md
+++ b/file_list.md
@@ -1,0 +1,1123 @@
+|序号|路径|作用说明|是否转换完成|
+|---|---|---|---|
+|1|./gen/DocumentFormat.OpenXml.Generator.Models/Converters/QualifiedNameConverter.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|2|./gen/DocumentFormat.OpenXml.Generator.Models/Converters/TypedQNameConverter.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|3|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/BlockOptions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|4|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/Delimiter.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|5|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/DocumentCommentExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|6|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/DocumentCommentOptions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|7|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/Indentation.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|8|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/Item.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|9|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/ItemType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|10|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/Paragraphs.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|11|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/Parameters.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|12|./gen/DocumentFormat.OpenXml.Generator.Models/Editor/TextWriterExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|13|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/DataModelWriterExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|14|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/ParticleWriterExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|15|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/SimpleTypeExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|16|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Elements/ValidatorWriterExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|17|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/FieldInfo.cs|Represents an XName field.| |
+|18|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/LinqGeneratorExtensions.cs|Code generator for the namespace-related Linq-to-Xml classes.| |
+|19|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/LinqVisitor.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|20|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Linq/ValidIdentifierHelper.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|21|./gen/DocumentFormat.OpenXml.Generator.Models/Generators/Parts/PartWriter.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|22|./gen/DocumentFormat.OpenXml.Generator.Models/Models/Argument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|23|./gen/DocumentFormat.OpenXml.Generator.Models/Models/ArgumentType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|24|./gen/DocumentFormat.OpenXml.Generator.Models/Models/NamespaceInfo.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|25|./gen/DocumentFormat.OpenXml.Generator.Models/Models/OfficeApplication.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|26|./gen/DocumentFormat.OpenXml.Generator.Models/Models/OfficeVersion.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|27|./gen/DocumentFormat.OpenXml.Generator.Models/Models/Part.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|28|./gen/DocumentFormat.OpenXml.Generator.Models/Models/PartChild.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|29|./gen/DocumentFormat.OpenXml.Generator.Models/Models/PartPaths.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|30|./gen/DocumentFormat.OpenXml.Generator.Models/Models/Particle.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|31|./gen/DocumentFormat.OpenXml.Generator.Models/Models/ParticleOrderType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|32|./gen/DocumentFormat.OpenXml.Generator.Models/Models/ParticleType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|33|./gen/DocumentFormat.OpenXml.Generator.Models/Models/ParticleVersion.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|34|./gen/DocumentFormat.OpenXml.Generator.Models/Models/QName.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|35|./gen/DocumentFormat.OpenXml.Generator.Models/Models/SchemaAttribute.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|36|./gen/DocumentFormat.OpenXml.Generator.Models/Models/SchemaElement.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|37|./gen/DocumentFormat.OpenXml.Generator.Models/Models/SchemaEnum.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|38|./gen/DocumentFormat.OpenXml.Generator.Models/Models/SchemaEnumFacet.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|39|./gen/DocumentFormat.OpenXml.Generator.Models/Models/SchemaNamespace.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|40|./gen/DocumentFormat.OpenXml.Generator.Models/Models/SchemaType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|41|./gen/DocumentFormat.OpenXml.Generator.Models/Models/StronglyTypedElement.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|42|./gen/DocumentFormat.OpenXml.Generator.Models/Models/StronglyTypedNamespace.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|43|./gen/DocumentFormat.OpenXml.Generator.Models/Models/StronglyTypedType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|44|./gen/DocumentFormat.OpenXml.Generator.Models/Models/TypeOf.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|45|./gen/DocumentFormat.OpenXml.Generator.Models/Models/TypedQName.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|46|./gen/DocumentFormat.OpenXml.Generator.Models/Models/Validator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|47|./gen/DocumentFormat.OpenXml.Generator.Models/Models/Verbatim.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|48|./gen/DocumentFormat.OpenXml.Generator.Models/OpenXmlGeneratorDataSource.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|49|./gen/DocumentFormat.OpenXml.Generator.Models/OpenXmlGeneratorServices.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|50|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/AttributeReference.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|51|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/CategoryIdentifier.cs|Class for category identification| |
+|52|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/ElementReference.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|53|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/ISchematron.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|54|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/IdentificationTreeNode.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|55|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_1.cs|AttrValueSetWhenOther| |
+|56|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_10.cs|ParseInvalidSetConstraint| |
+|57|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_12.cs|ParseAttributeLengthConstraint| |
+|58|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_14.cs|ParseAttrOmitWhenOther| |
+|59|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_15.cs|ParseAttrOmitWhenOtherNot| |
+|60|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_16.cs|AttrMutualExclusive| |
+|61|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_17.cs|AttrMinMax| |
+|62|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_18.cs|AttrRequiredWhenOther| |
+|63|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_19.cs|AttrValueSetWhenOther| |
+|64|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_2.cs|ParseAttributePatternConstraint| |
+|65|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_3.cs|ParseMinMaxConstraint| |
+|66|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron1_4.cs|ParseValidSetConstraint| |
+|67|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron2_1.cs|ParseRelExistConstraint| |
+|68|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron2_2.cs|ParseRelTypeConstraint| |
+|69|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron2_3.cs|ParseUniqueAttributeConstraint| |
+|70|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron3_1.cs|ParseRefExistConstraint| |
+|71|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron3_2.cs|ParseIndexedConstraint| |
+|72|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/KnownSchematrons/Schematron3_3.cs|ParseRootAttrConstraint| |
+|73|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/ParseContext.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|74|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/SchematronDataParser.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|75|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/SchematronEntry.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|76|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/SchematronVisitor.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|77|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/StringSchematronVisitor.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|78|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/SyntaxAnalysor.cs|Class for schematron statement analysis| |
+|79|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/SyntaxTree.cs|Syntax tree| |
+|80|./gen/DocumentFormat.OpenXml.Generator.Models/Schematron/SyntaxTreeNode.cs|Syntax tree node| |
+|81|./gen/DocumentFormat.OpenXml.Generator/GeneratorExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|82|./gen/DocumentFormat.OpenXml.Generator/IFeatureImplementationBuilder.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|83|./gen/DocumentFormat.OpenXml.Generator/NamespaceGeneration/NamespaceGenerator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|84|./gen/DocumentFormat.OpenXml.Generator/NamespaceGeneration/NamespaceGeneratorExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|85|./gen/DocumentFormat.OpenXml.Generator/OpenXmlGenerator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|86|./gen/DocumentFormat.OpenXml.Generator/OpenXmlGeneratorContext.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|87|./gen/DocumentFormat.OpenXml.Generator/OpenXmlGeneratorOptions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|88|./gen/DocumentFormat.OpenXml.Generator/PackageGeneratorExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|89|./gen/DocumentFormat.OpenXml.Generator/PackageInformation.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|90|./gen/DocumentFormat.OpenXml.Generator/ParentClass.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|91|./gen/DocumentFormat.OpenXml.Generator/PartGenerator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|92|./gen/DocumentFormat.OpenXml.Generator/RoslynExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|93|./gen/DocumentFormat.OpenXml.Generator/SchemaGenerator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|94|./generated/DocumentFormat.OpenXml.Framework/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Attributes.g.cs|| |
+|95|./generated/DocumentFormat.OpenXml.Framework/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Namespaces.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|96|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Attributes.g.cs|| |
+|97|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.A.g.cs|Declares XNamespace and XName fields for the xmlns:a="http://schemas.openxmlformats.org/drawingml/2006/main" namespace.| |
+|98|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.A14.g.cs|Declares XNamespace and XName fields for the xmlns:a14="http://schemas.microsoft.com/office/drawing/2010/main" namespace.| |
+|99|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.A15.g.cs|Declares XNamespace and XName fields for the xmlns:a15="http://schemas.microsoft.com/office/drawing/2012/main" namespace.| |
+|100|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.A16.g.cs|Declares XNamespace and XName fields for the xmlns:a16="http://schemas.microsoft.com/office/drawing/2014/main" namespace.| |
+|101|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.A1611.g.cs|Declares XNamespace and XName fields for the xmlns:a1611="http://schemas.microsoft.com/office/drawing/2016/11/main" namespace.| |
+|102|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.AC.g.cs|Declares XNamespace and XName fields for the xmlns:ac="http://schemas.openxmlformats.org/officeDocument/2006/characteristics" namespace.| |
+|103|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.ACLSH.g.cs|Declares XNamespace and XName fields for the xmlns:aclsh="http://schemas.microsoft.com/office/drawing/2020/classificationShape" namespace.| |
+|104|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.ADEC.g.cs|Declares XNamespace and XName fields for the xmlns:adec="http://schemas.microsoft.com/office/drawing/2017/decorative" namespace.| |
+|105|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.AHYP.g.cs|Declares XNamespace and XName fields for the xmlns:ahyp="http://schemas.microsoft.com/office/drawing/2018/hyperlinkcolor" namespace.| |
+|106|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.AIF.g.cs|Declares XNamespace and XName fields for the xmlns:aif="http://schemas.microsoft.com/office/drawing/2022/imageformula" namespace.| |
+|107|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.ALF.g.cs|Declares XNamespace and XName fields for the xmlns:alf="http://schemas.microsoft.com/office/drawing/2021/livefeed" namespace.| |
+|108|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.AM3D.g.cs|Declares XNamespace and XName fields for the xmlns:am3d="http://schemas.microsoft.com/office/drawing/2017/model3d" namespace.| |
+|109|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.AOE.g.cs|Declares XNamespace and XName fields for the xmlns:aoe="http://schemas.microsoft.com/office/drawing/2021/oembed" namespace.| |
+|110|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.AP.g.cs|Declares XNamespace and XName fields for the xmlns:ap="http://schemas.openxmlformats.org/officeDocument/2006/extended-properties" namespace.| |
+|111|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.ASK.g.cs|Declares XNamespace and XName fields for the xmlns:ask="http://schemas.microsoft.com/office/drawing/2018/sketchyshapes" namespace.| |
+|112|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.ASL.g.cs|Declares XNamespace and XName fields for the xmlns:asl="http://schemas.microsoft.com/office/drawing/2021/scriptlink" namespace.| |
+|113|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.ASVG.g.cs|Declares XNamespace and XName fields for the xmlns:asvg="http://schemas.microsoft.com/office/drawing/2016/SVG/main" namespace.| |
+|114|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.B.g.cs|Declares XNamespace and XName fields for the xmlns:b="http://schemas.openxmlformats.org/officeDocument/2006/bibliography" namespace.| |
+|115|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.C.g.cs|Declares XNamespace and XName fields for the xmlns:c="http://schemas.openxmlformats.org/drawingml/2006/chart" namespace.| |
+|116|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.C14.g.cs|Declares XNamespace and XName fields for the xmlns:c14="http://schemas.microsoft.com/office/drawing/2007/8/2/chart" namespace.| |
+|117|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.C15.g.cs|Declares XNamespace and XName fields for the xmlns:c15="http://schemas.microsoft.com/office/drawing/2012/chart" namespace.| |
+|118|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.C16.g.cs|Declares XNamespace and XName fields for the xmlns:c16="http://schemas.microsoft.com/office/drawing/2014/chart" namespace.| |
+|119|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.C16R3.g.cs|Declares XNamespace and XName fields for the xmlns:c16r3="http://schemas.microsoft.com/office/drawing/2017/03/chart" namespace.| |
+|120|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.CDR.g.cs|Declares XNamespace and XName fields for the xmlns:cdr="http://schemas.openxmlformats.org/drawingml/2006/chartDrawing" namespace.| |
+|121|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.CDR14.g.cs|Declares XNamespace and XName fields for the xmlns:cdr14="http://schemas.microsoft.com/office/drawing/2010/chartDrawing" namespace.| |
+|122|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.CLBL.g.cs|Declares XNamespace and XName fields for the xmlns:clbl="http://schemas.microsoft.com/office/2020/mipLabelMetadata" namespace.| |
+|123|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.COMP.g.cs|Declares XNamespace and XName fields for the xmlns:comp="http://schemas.openxmlformats.org/drawingml/2006/compatibility" namespace.| |
+|124|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.CS.g.cs|Declares XNamespace and XName fields for the xmlns:cs="http://schemas.microsoft.com/office/drawing/2012/chartStyle" namespace.| |
+|125|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.CX.g.cs|Declares XNamespace and XName fields for the xmlns:cx="http://schemas.microsoft.com/office/drawing/2014/chartex" namespace.| |
+|126|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.DGM.g.cs|Declares XNamespace and XName fields for the xmlns:dgm="http://schemas.openxmlformats.org/drawingml/2006/diagram" namespace.| |
+|127|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.DGM14.g.cs|Declares XNamespace and XName fields for the xmlns:dgm14="http://schemas.microsoft.com/office/drawing/2010/diagram" namespace.| |
+|128|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.DGM1611.g.cs|Declares XNamespace and XName fields for the xmlns:dgm1611="http://schemas.microsoft.com/office/drawing/2016/11/diagram" namespace.| |
+|129|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.DGM1612.g.cs|Declares XNamespace and XName fields for the xmlns:dgm1612="http://schemas.microsoft.com/office/drawing/2016/12/diagram" namespace.| |
+|130|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.DS.g.cs|Declares XNamespace and XName fields for the xmlns:ds="http://schemas.openxmlformats.org/officeDocument/2006/customXml" namespace.| |
+|131|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.DSP.g.cs|Declares XNamespace and XName fields for the xmlns:dsp="http://schemas.microsoft.com/office/drawing/2008/diagram" namespace.| |
+|132|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.EMMA.g.cs|Declares XNamespace and XName fields for the xmlns:emma="http://www.w3.org/2003/04/emma" namespace.| |
+|133|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.INKML.g.cs|Declares XNamespace and XName fields for the xmlns:inkml="http://www.w3.org/2003/InkML" namespace.| |
+|134|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.LC.g.cs|Declares XNamespace and XName fields for the xmlns:lc="http://schemas.openxmlformats.org/drawingml/2006/lockedCanvas" namespace.| |
+|135|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.M.g.cs|Declares XNamespace and XName fields for the xmlns:m="http://schemas.openxmlformats.org/officeDocument/2006/math" namespace.| |
+|136|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.MSINK.g.cs|Declares XNamespace and XName fields for the xmlns:msink="http://schemas.microsoft.com/ink/2010/main" namespace.| |
+|137|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.MSO.g.cs|Declares XNamespace and XName fields for the xmlns:mso="http://schemas.microsoft.com/office/2006/01/customui" namespace.| |
+|138|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.MSO14.g.cs|Declares XNamespace and XName fields for the xmlns:mso14="http://schemas.microsoft.com/office/2009/07/customui" namespace.| |
+|139|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.NoNamespace.g.cs|Declares XName fields for the empty namespace.| |
+|140|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.O.g.cs|Declares XNamespace and XName fields for the xmlns:o="urn:schemas-microsoft-com:office:office" namespace.| |
+|141|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.OAC.g.cs|Declares XNamespace and XName fields for the xmlns:oac="http://schemas.microsoft.com/office/drawing/2013/main/command" namespace.| |
+|142|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.OEL.g.cs|Declares XNamespace and XName fields for the xmlns:oel="http://schemas.microsoft.com/office/2019/extlst" namespace.| |
+|143|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.OP.g.cs|Declares XNamespace and XName fields for the xmlns:op="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" namespace.| |
+|144|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P.g.cs|Declares XNamespace and XName fields for the xmlns:p="http://schemas.openxmlformats.org/presentationml/2006/main" namespace.| |
+|145|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P14.g.cs|Declares XNamespace and XName fields for the xmlns:p14="http://schemas.microsoft.com/office/powerpoint/2010/main" namespace.| |
+|146|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P15.g.cs|Declares XNamespace and XName fields for the xmlns:p15="http://schemas.microsoft.com/office/powerpoint/2012/main" namespace.| |
+|147|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P188.g.cs|Declares XNamespace and XName fields for the xmlns:p188="http://schemas.microsoft.com/office/powerpoint/2018/8/main" namespace.| |
+|148|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P1912.g.cs|Declares XNamespace and XName fields for the xmlns:p1912="http://schemas.microsoft.com/office/powerpoint/2019/12/main" namespace.| |
+|149|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P223.g.cs|Declares XNamespace and XName fields for the xmlns:p223="http://schemas.microsoft.com/office/powerpoint/2022/03/main" namespace.| |
+|150|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P228.g.cs|Declares XNamespace and XName fields for the xmlns:p228="http://schemas.microsoft.com/office/powerpoint/2022/08/main" namespace.| |
+|151|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.P232.g.cs|Declares XNamespace and XName fields for the xmlns:p232="http://schemas.microsoft.com/office/powerpoint/2023/02/main" namespace.| |
+|152|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.PC.g.cs|Declares XNamespace and XName fields for the xmlns:pc="http://schemas.microsoft.com/office/powerpoint/2013/main/command" namespace.| |
+|153|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.PIC.g.cs|Declares XNamespace and XName fields for the xmlns:pic="http://schemas.openxmlformats.org/drawingml/2006/picture" namespace.| |
+|154|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.PIC14.g.cs|Declares XNamespace and XName fields for the xmlns:pic14="http://schemas.microsoft.com/office/drawing/2010/picture" namespace.| |
+|155|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.PVML.g.cs|Declares XNamespace and XName fields for the xmlns:pvml="urn:schemas-microsoft-com:office:powerpoint" namespace.| |
+|156|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.R.g.cs|Declares XNamespace and XName fields for the xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships" namespace.| |
+|157|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.SL.g.cs|Declares XNamespace and XName fields for the xmlns:sl="http://schemas.openxmlformats.org/schemaLibrary/2006/main" namespace.| |
+|158|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.SLE.g.cs|Declares XNamespace and XName fields for the xmlns:sle="http://schemas.microsoft.com/office/drawing/2010/slicer" namespace.| |
+|159|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.T.g.cs|Declares XNamespace and XName fields for the xmlns:t="http://schemas.microsoft.com/office/tasks/2019/documenttasks" namespace.| |
+|160|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.THM15.g.cs|Declares XNamespace and XName fields for the xmlns:thm15="http://schemas.microsoft.com/office/thememl/2012/main" namespace.| |
+|161|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.TSLE.g.cs|Declares XNamespace and XName fields for the xmlns:tsle="http://schemas.microsoft.com/office/drawing/2012/timeslicer" namespace.| |
+|162|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.V.g.cs|Declares XNamespace and XName fields for the xmlns:v="urn:schemas-microsoft-com:vml" namespace.| |
+|163|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.VT.g.cs|Declares XNamespace and XName fields for the xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes" namespace.| |
+|164|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W.g.cs|Declares XNamespace and XName fields for the xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" namespace.| |
+|165|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W10.g.cs|Declares XNamespace and XName fields for the xmlns:w10="urn:schemas-microsoft-com:office:word" namespace.| |
+|166|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W14.g.cs|Declares XNamespace and XName fields for the xmlns:w14="http://schemas.microsoft.com/office/word/2010/wordml" namespace.| |
+|167|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W15.g.cs|Declares XNamespace and XName fields for the xmlns:w15="http://schemas.microsoft.com/office/word/2012/wordml" namespace.| |
+|168|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W16CEX.g.cs|Declares XNamespace and XName fields for the xmlns:w16cex="http://schemas.microsoft.com/office/word/2018/wordml/cex" namespace.| |
+|169|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W16CID.g.cs|Declares XNamespace and XName fields for the xmlns:w16cid="http://schemas.microsoft.com/office/word/2016/wordml/cid" namespace.| |
+|170|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W16CUR.g.cs|Declares XNamespace and XName fields for the xmlns:w16cur="http://schemas.microsoft.com/office/word/2018/wordml" namespace.| |
+|171|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.W16DU.g.cs|Declares XNamespace and XName fields for the xmlns:w16du="http://schemas.microsoft.com/office/word/2023/wordml/word16du" namespace.| |
+|172|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WE.g.cs|Declares XNamespace and XName fields for the xmlns:we="http://schemas.microsoft.com/office/webextensions/webextension/2010/11" namespace.| |
+|173|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WETP.g.cs|Declares XNamespace and XName fields for the xmlns:wetp="http://schemas.microsoft.com/office/webextensions/taskpanes/2010/11" namespace.| |
+|174|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WNE.g.cs|Declares XNamespace and XName fields for the xmlns:wne="http://schemas.microsoft.com/office/word/2006/wordml" namespace.| |
+|175|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WOE.g.cs|Declares XNamespace and XName fields for the xmlns:woe="http://schemas.microsoft.com/office/word/2020/oembed" namespace.| |
+|176|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WP.g.cs|Declares XNamespace and XName fields for the xmlns:wp="http://schemas.openxmlformats.org/drawingml/2006/wordprocessingDrawing" namespace.| |
+|177|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WP14.g.cs|Declares XNamespace and XName fields for the xmlns:wp14="http://schemas.microsoft.com/office/word/2010/wordprocessingDrawing" namespace.| |
+|178|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WP15.g.cs|Declares XNamespace and XName fields for the xmlns:wp15="http://schemas.microsoft.com/office/word/2012/wordprocessingDrawing" namespace.| |
+|179|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WPC.g.cs|Declares XNamespace and XName fields for the xmlns:wpc="http://schemas.microsoft.com/office/word/2010/wordprocessingCanvas" namespace.| |
+|180|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WPG.g.cs|Declares XNamespace and XName fields for the xmlns:wpg="http://schemas.microsoft.com/office/word/2010/wordprocessingGroup" namespace.| |
+|181|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.WPS.g.cs|Declares XNamespace and XName fields for the xmlns:wps="http://schemas.microsoft.com/office/word/2010/wordprocessingShape" namespace.| |
+|182|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X.g.cs|Declares XNamespace and XName fields for the xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main" namespace.| |
+|183|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X12AC.g.cs|Declares XNamespace and XName fields for the xmlns:x12ac="http://schemas.microsoft.com/office/spreadsheetml/2011/1/ac" namespace.| |
+|184|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X14.g.cs|Declares XNamespace and XName fields for the xmlns:x14="http://schemas.microsoft.com/office/spreadsheetml/2009/9/main" namespace.| |
+|185|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X14AC.g.cs|Declares XNamespace and XName fields for the xmlns:x14ac="http://schemas.microsoft.com/office/spreadsheetml/2009/9/ac" namespace.| |
+|186|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X15.g.cs|Declares XNamespace and XName fields for the xmlns:x15="http://schemas.microsoft.com/office/spreadsheetml/2010/11/main" namespace.| |
+|187|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.X15AC.g.cs|Declares XNamespace and XName fields for the xmlns:x15ac="http://schemas.microsoft.com/office/spreadsheetml/2010/11/ac" namespace.| |
+|188|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XDR.g.cs|Declares XNamespace and XName fields for the xmlns:xdr="http://schemas.openxmlformats.org/drawingml/2006/spreadsheetDrawing" namespace.| |
+|189|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XDR14.g.cs|Declares XNamespace and XName fields for the xmlns:xdr14="http://schemas.microsoft.com/office/excel/2010/spreadsheetDrawing" namespace.| |
+|190|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XFPB.g.cs|Declares XNamespace and XName fields for the xmlns:xfpb="http://schemas.microsoft.com/office/spreadsheetml/2022/featurepropertybag" namespace.| |
+|191|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLECS.g.cs|Declares XNamespace and XName fields for the xmlns:xlecs="http://schemas.microsoft.com/office/spreadsheetml/2023/externalCodeService" namespace.| |
+|192|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLMSFORMS.g.cs|Declares XNamespace and XName fields for the xmlns:xlmsforms="http://schemas.microsoft.com/office/spreadsheetml/2023/msForms" namespace.| |
+|193|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLPAR.g.cs|Declares XNamespace and XName fields for the xmlns:xlpar="http://schemas.microsoft.com/office/spreadsheetml/2024/pivotAutoRefresh" namespace.| |
+|194|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLPDA.g.cs|Declares XNamespace and XName fields for the xmlns:xlpda="http://schemas.microsoft.com/office/spreadsheetml/2024/pivotDynamicArrays" namespace.| |
+|195|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLRD.g.cs|Declares XNamespace and XName fields for the xmlns:xlrd="http://schemas.microsoft.com/office/spreadsheetml/2017/richdata" namespace.| |
+|196|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLRD2.g.cs|Declares XNamespace and XName fields for the xmlns:xlrd2="http://schemas.microsoft.com/office/spreadsheetml/2017/richdata2" namespace.| |
+|197|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLRDWI.g.cs|Declares XNamespace and XName fields for the xmlns:xlrdwi="http://schemas.microsoft.com/office/spreadsheetml/2020/richdatawebimage" namespace.| |
+|198|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLTC.g.cs|Declares XNamespace and XName fields for the xmlns:xltc="http://schemas.microsoft.com/office/spreadsheetml/2018/threadedcomments" namespace.| |
+|199|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XLWCV.g.cs|Declares XNamespace and XName fields for the xmlns:xlwcv="http://schemas.microsoft.com/office/spreadsheetml/2024/workbookCompatibilityVersion" namespace.| |
+|200|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XML.g.cs|Declares XNamespace and XName fields for the xmlns:xml="http://www.w3.org/XML/1998/namespace" namespace.| |
+|201|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XNE.g.cs|Declares XNamespace and XName fields for the xmlns:xne="http://schemas.microsoft.com/office/excel/2006/main" namespace.| |
+|202|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XNSV.g.cs|Declares XNamespace and XName fields for the xmlns:xnsv="http://schemas.microsoft.com/office/spreadsheetml/2019/namedsheetviews" namespace.| |
+|203|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XPRD.g.cs|Declares XNamespace and XName fields for the xmlns:xprd="http://schemas.microsoft.com/office/spreadsheetml/2022/pivotRichData" namespace.| |
+|204|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XR.g.cs|Declares XNamespace and XName fields for the xmlns:xr="http://schemas.microsoft.com/office/spreadsheetml/2014/revision" namespace.| |
+|205|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XVML.g.cs|Declares XNamespace and XName fields for the xmlns:xvml="urn:schemas-microsoft-com:office:excel" namespace.| |
+|206|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XXL21.g.cs|Declares XNamespace and XName fields for the xmlns:xxl21="http://schemas.microsoft.com/office/spreadsheetml/2021/extlinks2021" namespace.| |
+|207|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XXPIM.g.cs|Declares XNamespace and XName fields for the xmlns:xxpim="http://schemas.microsoft.com/office/spreadsheetml/2020/pivotNov2020" namespace.| |
+|208|./generated/DocumentFormat.OpenXml.Linq/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Linq.XXPVI.g.cs|Declares XNamespace and XName fields for the xmlns:xxpvi="http://schemas.microsoft.com/office/spreadsheetml/2022/pivotVersionInfo" namespace.| |
+|209|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Attributes.g.cs|| |
+|210|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_PresentationDocument_IPartFactoryFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|211|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_PresentationDocument_IRootElementFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|212|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_PresentationDocument_ITypedPartFactoryFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|213|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_SpreadsheetDocument_IPartFactoryFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|214|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_SpreadsheetDocument_IRootElementFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|215|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_SpreadsheetDocument_ITypedPartFactoryFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|216|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_WordprocessingDocument_IPartFactoryFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|217|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_WordprocessingDocument_IRootElementFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|218|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Package_WordprocessingDocument_ITypedPartFactoryFeature.g.cs|Copyright (c) Microsoft. All rights reserved.| |
+|219|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_AlternativeFormatImportPart.g.cs|Defines the AlternativeFormatImportPart| |
+|220|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CalculationChainPart.g.cs|Defines the CalculationChainPart| |
+|221|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CellMetadataPart.g.cs|Defines the CellMetadataPart| |
+|222|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartColorStylePart.g.cs|Defines the ChartColorStylePart| |
+|223|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartDrawingPart.g.cs|Defines the ChartDrawingPart| |
+|224|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartPart.g.cs|Defines the ChartPart| |
+|225|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartStylePart.g.cs|Defines the ChartStylePart| |
+|226|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ChartsheetPart.g.cs|Defines the ChartsheetPart| |
+|227|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CommentAuthorsPart.g.cs|Defines the CommentAuthorsPart| |
+|228|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ConnectionsPart.g.cs|Defines the ConnectionsPart| |
+|229|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ControlPropertiesPart.g.cs|Defines the ControlPropertiesPart| |
+|230|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CoreFilePropertiesPart.g.cs|Defines the CoreFilePropertiesPart| |
+|231|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomDataPart.g.cs|Defines the CustomDataPart| |
+|232|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomDataPropertiesPart.g.cs|Defines the CustomDataPropertiesPart| |
+|233|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomFilePropertiesPart.g.cs|Defines the CustomFilePropertiesPart| |
+|234|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomPropertyPart.g.cs|Defines the CustomPropertyPart| |
+|235|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlMappingsPart.g.cs|Defines the CustomXmlMappingsPart| |
+|236|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlPart.g.cs|Defines the CustomXmlPart| |
+|237|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomXmlPropertiesPart.g.cs|Defines the CustomXmlPropertiesPart| |
+|238|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_CustomizationPart.g.cs|Defines the CustomizationPart| |
+|239|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramColorsPart.g.cs|Defines the DiagramColorsPart| |
+|240|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramDataPart.g.cs|Defines the DiagramDataPart| |
+|241|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramLayoutDefinitionPart.g.cs|Defines the DiagramLayoutDefinitionPart| |
+|242|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramPersistLayoutPart.g.cs|Defines the DiagramPersistLayoutPart| |
+|243|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DiagramStylePart.g.cs|Defines the DiagramStylePart| |
+|244|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DialogsheetPart.g.cs|Defines the DialogsheetPart| |
+|245|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DigitalSignatureOriginPart.g.cs|Defines the DigitalSignatureOriginPart| |
+|246|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DocumentSettingsPart.g.cs|Defines the DocumentSettingsPart| |
+|247|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DocumentTasksPart.g.cs|Defines the DocumentTasksPart| |
+|248|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_DrawingsPart.g.cs|Defines the DrawingsPart| |
+|249|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedControlPersistenceBinaryDataPart.g.cs|Defines the EmbeddedControlPersistenceBinaryDataPart| |
+|250|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedControlPersistencePart.g.cs|Defines the EmbeddedControlPersistencePart| |
+|251|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedObjectPart.g.cs|Defines the EmbeddedObjectPart| |
+|252|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EmbeddedPackagePart.g.cs|Defines the EmbeddedPackagePart| |
+|253|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_EndnotesPart.g.cs|Defines the EndnotesPart| |
+|254|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExcelAttachedToolbarsPart.g.cs|Defines the ExcelAttachedToolbarsPart| |
+|255|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExtendedChartPart.g.cs|Defines the ExtendedChartPart| |
+|256|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExtendedFilePropertiesPart.g.cs|Defines the ExtendedFilePropertiesPart| |
+|257|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ExternalWorkbookPart.g.cs|Defines the ExternalWorkbookPart| |
+|258|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FeaturePropertyBagsPart.g.cs|Defines the FeaturePropertyBagsPart| |
+|259|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FontPart.g.cs|Defines the FontPart| |
+|260|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FontTablePart.g.cs|Defines the FontTablePart| |
+|261|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FooterPart.g.cs|Defines the FooterPart| |
+|262|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_FootnotesPart.g.cs|Defines the FootnotesPart| |
+|263|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_GlossaryDocumentPart.g.cs|Defines the GlossaryDocumentPart| |
+|264|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_HandoutMasterPart.g.cs|Defines the HandoutMasterPart| |
+|265|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_HeaderPart.g.cs|Defines the HeaderPart| |
+|266|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ImagePart.g.cs|Defines the ImagePart| |
+|267|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_InternationalMacroSheetPart.g.cs|Defines the InternationalMacroSheetPart| |
+|268|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LabelInfoPart.g.cs|Defines the LabelInfoPart| |
+|269|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LegacyDiagramTextInfoPart.g.cs|Defines the LegacyDiagramTextInfoPart| |
+|270|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_LegacyDiagramTextPart.g.cs|Defines the LegacyDiagramTextPart| |
+|271|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MacroSheetPart.g.cs|Defines the MacroSheetPart| |
+|272|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MailMergeRecipientDataPart.g.cs|Defines the MailMergeRecipientDataPart| |
+|273|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_MainDocumentPart.g.cs|Defines the MainDocumentPart| |
+|274|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_Model3DReferenceRelationshipPart.g.cs|Defines the Model3DReferenceRelationshipPart| |
+|275|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NamedSheetViewsPart.g.cs|Defines the NamedSheetViewsPart| |
+|276|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NotesMasterPart.g.cs|Defines the NotesMasterPart| |
+|277|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NotesSlidePart.g.cs|Defines the NotesSlidePart| |
+|278|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_NumberingDefinitionsPart.g.cs|Defines the NumberingDefinitionsPart| |
+|279|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTableCacheDefinitionPart.g.cs|Defines the PivotTableCacheDefinitionPart| |
+|280|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTableCacheRecordsPart.g.cs|Defines the PivotTableCacheRecordsPart| |
+|281|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PivotTablePart.g.cs|Defines the PivotTablePart| |
+|282|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PowerPointAuthorsPart.g.cs|Defines the PowerPointAuthorsPart| |
+|283|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PowerPointCommentPart.g.cs|Defines the PowerPointCommentPart| |
+|284|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PresentationDocument.g.cs|Defines the PresentationDocument| |
+|285|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PresentationPart.g.cs|Defines the PresentationPart| |
+|286|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_PresentationPropertiesPart.g.cs|Defines the PresentationPropertiesPart| |
+|287|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_QueryTablePart.g.cs|Defines the QueryTablePart| |
+|288|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_QuickAccessToolbarCustomizationsPart.g.cs|Defines the QuickAccessToolbarCustomizationsPart| |
+|289|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdArrayPart.g.cs|Defines the RdArrayPart| |
+|290|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValuePart.g.cs|Defines the RdRichValuePart| |
+|291|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueStructurePart.g.cs|Defines the RdRichValueStructurePart| |
+|292|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueTypesPart.g.cs|Defines the RdRichValueTypesPart| |
+|293|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdRichValueWebImagePart.g.cs|Defines the RdRichValueWebImagePart| |
+|294|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdSupportingPropertyBagPart.g.cs|Defines the RdSupportingPropertyBagPart| |
+|295|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RdSupportingPropertyBagStructurePart.g.cs|Defines the RdSupportingPropertyBagStructurePart| |
+|296|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RibbonAndBackstageCustomizationsPart.g.cs|Defines the RibbonAndBackstageCustomizationsPart| |
+|297|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RibbonExtensibilityPart.g.cs|Defines the RibbonExtensibilityPart| |
+|298|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_RichStylesPart.g.cs|Defines the RichStylesPart| |
+|299|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SharedStringTablePart.g.cs|Defines the SharedStringTablePart| |
+|300|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SingleCellTablePart.g.cs|Defines the SingleCellTablePart| |
+|301|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlicerCachePart.g.cs|Defines the SlicerCachePart| |
+|302|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlicersPart.g.cs|Defines the SlicersPart| |
+|303|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideCommentsPart.g.cs|Defines the SlideCommentsPart| |
+|304|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideLayoutPart.g.cs|Defines the SlideLayoutPart| |
+|305|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideMasterPart.g.cs|Defines the SlideMasterPart| |
+|306|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlidePart.g.cs|Defines the SlidePart| |
+|307|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SlideSyncDataPart.g.cs|Defines the SlideSyncDataPart| |
+|308|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SpreadsheetDocument.g.cs|Defines the SpreadsheetDocument| |
+|309|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_SpreadsheetPrinterSettingsPart.g.cs|Defines the SpreadsheetPrinterSettingsPart| |
+|310|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_StyleDefinitionsPart.g.cs|Defines the StyleDefinitionsPart| |
+|311|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_StylesWithEffectsPart.g.cs|Defines the StylesWithEffectsPart| |
+|312|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TableDefinitionPart.g.cs|Defines the TableDefinitionPart| |
+|313|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TableStylesPart.g.cs|Defines the TableStylesPart| |
+|314|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThemeOverridePart.g.cs|Defines the ThemeOverridePart| |
+|315|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThemePart.g.cs|Defines the ThemePart| |
+|316|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ThumbnailPart.g.cs|Defines the ThumbnailPart| |
+|317|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TimeLineCachePart.g.cs|Defines the TimeLineCachePart| |
+|318|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_TimeLinePart.g.cs|Defines the TimeLinePart| |
+|319|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_UserDefinedTagsPart.g.cs|Defines the UserDefinedTagsPart| |
+|320|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VbaDataPart.g.cs|Defines the VbaDataPart| |
+|321|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VbaProjectPart.g.cs|Defines the VbaProjectPart| |
+|322|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_ViewPropertiesPart.g.cs|Defines the ViewPropertiesPart| |
+|323|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VmlDrawingPart.g.cs|Defines the VmlDrawingPart| |
+|324|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_VolatileDependenciesPart.g.cs|Defines the VolatileDependenciesPart| |
+|325|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebExTaskpanesPart.g.cs|Defines the WebExTaskpanesPart| |
+|326|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebExtensionPart.g.cs|Defines the WebExtensionPart| |
+|327|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WebSettingsPart.g.cs|Defines the WebSettingsPart| |
+|328|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordAttachedToolbarsPart.g.cs|Defines the WordAttachedToolbarsPart| |
+|329|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordCommentsExtensiblePart.g.cs|Defines the WordCommentsExtensiblePart| |
+|330|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsExPart.g.cs|Defines the WordprocessingCommentsExPart| |
+|331|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsIdsPart.g.cs|Defines the WordprocessingCommentsIdsPart| |
+|332|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingCommentsPart.g.cs|Defines the WordprocessingCommentsPart| |
+|333|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingDocument.g.cs|Defines the WordprocessingDocument| |
+|334|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingPeoplePart.g.cs|Defines the WordprocessingPeoplePart| |
+|335|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WordprocessingPrinterSettingsPart.g.cs|Defines the WordprocessingPrinterSettingsPart| |
+|336|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookPart.g.cs|Defines the WorkbookPart| |
+|337|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookPersonPart.g.cs|Defines the WorkbookPersonPart| |
+|338|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookRevisionHeaderPart.g.cs|Defines the WorkbookRevisionHeaderPart| |
+|339|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookRevisionLogPart.g.cs|Defines the WorkbookRevisionLogPart| |
+|340|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookStylesPart.g.cs|Defines the WorkbookStylesPart| |
+|341|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorkbookUserDataPart.g.cs|Defines the WorkbookUserDataPart| |
+|342|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetCommentsPart.g.cs|Defines the WorksheetCommentsPart| |
+|343|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetPart.g.cs|Defines the WorksheetPart| |
+|344|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetSortMapPart.g.cs|Defines the WorksheetSortMapPart| |
+|345|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_WorksheetThreadedCommentsPart.g.cs|Defines the WorksheetThreadedCommentsPart| |
+|346|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/Part_XmlSignaturePart.g.cs|Defines the XmlSignaturePart| |
+|347|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas-microsoft-com_office_excel.g.cs|<para>Attached Object Data.</para>| |
+|348|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas-microsoft-com_office_office.g.cs|<para>New Shape Defaults.</para>| |
+|349|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas-microsoft-com_office_powerpoint.g.cs|<para>Ink Annotation Flag.</para>| |
+|350|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas-microsoft-com_office_word.g.cs|<para>Top Border.</para>| |
+|351|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas-microsoft-com_vml.g.cs|<para>Defines the Path Class.</para>| |
+|352|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_ink_2010_main.g.cs|<para>Defines the ContextNode Class.</para>| |
+|353|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_01_customui.g.cs|<para>Defines the UnsizedControlClone Class.</para>| |
+|354|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_activeX.g.cs|<para>Defines the ActiveXControlData Class.</para>| |
+|355|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_coverPageProps.g.cs|<para>Defines the CoverPageProperties Class.</para>| |
+|356|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_customDocumentInformationPanel.g.cs|<para>Defines the CustomPropertyEditors Class.</para>| |
+|357|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_metadata_contentType.g.cs|<para>Defines the ContentTypeSchema Class.</para>| |
+|358|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_metadata_customXsn.g.cs|<para>Defines the CustomXsn Class.</para>| |
+|359|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_metadata_longProperties.g.cs|<para>Defines the LongProperties Class.</para>| |
+|360|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2006_metadata_properties_metaAttributes.g.cs|<para>Defines the Dummy Class.</para>| |
+|361|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2009_07_customui.g.cs|<para>Defines the ControlCloneRegular Class.</para>| |
+|362|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2019_extlst.g.cs|<para>Defines the Extension Class.</para>| |
+|363|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_2020_mipLabelMetadata.g.cs|<para>Defines the ClassificationLabelList Class.</para>| |
+|364|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2007_8_2_chart.g.cs|<para>Defines the PivotOptions Class.</para>| |
+|365|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2008_diagram.g.cs|<para>Defines the Drawing Class.</para>| |
+|366|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2010_chartDrawing.g.cs|<para>Defines the ContentPart Class.</para>| |
+|367|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2010_compatibility.g.cs|<para>Defines the CompatibilityShape Class.</para>| |
+|368|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2010_diagram.g.cs|<para>Defines the NonVisualDrawingProperties Class.</para>| |
+|369|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2010_main.g.cs|<para>Defines the CameraTool Class.</para>| |
+|370|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2010_picture.g.cs|<para>Defines the ShapeStyle Class.</para>| |
+|371|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2010_slicer.g.cs|<para>Defines the Slicer Class.</para>| |
+|372|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_chart.g.cs|<para>Defines the PivotSource Class.</para>| |
+|373|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_chartStyle.g.cs|<para>Defines the ColorStyle Class.</para>| |
+|374|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_main.g.cs|<para>Defines the BackgroundProperties Class.</para>| |
+|375|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2012_timeslicer.g.cs|<para>Defines the TimeSlicer Class.</para>| |
+|376|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2013_main_command.g.cs|<para>Defines the ShapeMoniker Class.</para>| |
+|377|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2014_chart.g.cs|<para>Defines the ShapeProperties Class.</para>| |
+|378|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2014_chart_ac.g.cs|<para>Defines the MultiLvlStrData Class.</para>| |
+|379|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2014_chartex.g.cs|<para>Defines the ChartSpace Class.</para>| |
+|380|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2014_main.g.cs|<para>Defines the CreationId Class.</para>| |
+|381|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2016_11_diagram.g.cs|<para>Defines the NumberDiagramInfoList Class.</para>| |
+|382|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2016_11_main.g.cs|<para>Defines the PictureAttributionSourceURL Class.</para>| |
+|383|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2016_12_diagram.g.cs|<para>Defines the ShapeProperties Class.</para>| |
+|384|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2016_SVG_main.g.cs|<para>Defines the SVGBlip Class.</para>| |
+|385|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2016_ink.g.cs|Defines the ExtendedBrushPropertyName enumeration.| |
+|386|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2017_03_chart.g.cs|<para>Defines the DataDisplayOptions16 Class.</para>| |
+|387|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2017_decorative.g.cs|<para>Defines the Decorative Class.</para>| |
+|388|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2017_model3d.g.cs|<para>Defines the Model3D Class.</para>| |
+|389|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2018_animation.g.cs|<para>Defines the AnimationProperties Class.</para>| |
+|390|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2018_animation_model3d.g.cs|<para>Defines the EmbeddedAnimation Class.</para>| |
+|391|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2018_hyperlinkcolor.g.cs|<para>Defines the HyperlinkColor Class.</para>| |
+|392|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2018_sketchyshapes.g.cs|<para>Defines the LineSketchNoneEmpty Class.</para>| |
+|393|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2020_classificationShape.g.cs|<para>Defines the ClassificationOutcome Class.</para>| |
+|394|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2021_livefeed.g.cs|<para>Defines the BackgroundNormalProperties Class.</para>| |
+|395|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2021_oembed.g.cs|<para>Defines the OEmbedShared Class.</para>| |
+|396|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2021_scriptlink.g.cs|<para>Defines the ScriptLink Class.</para>| |
+|397|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_drawing_2022_imageformula.g.cs|<para>Defines the ImageFormula Class.</para>| |
+|398|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_excel_2006_main.g.cs|<para>Defines the Macrosheet Class.</para>| |
+|399|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_excel_2010_spreadsheetDrawing.g.cs|<para>Defines the ContentPart Class.</para>| |
+|400|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2010_main.g.cs|<para>Defines the NonVisualContentPartProperties Class.</para>| |
+|401|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2012_main.g.cs|<para>Defines the PresetTransition Class.</para>| |
+|402|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2012_roamingSettings.g.cs|<para>Defines the Key Class.</para>| |
+|403|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2013_main_command.g.cs|<para>Defines the CommentAuthorMonikerList Class.</para>| |
+|404|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2015_main.g.cs|<para>Defines the DesignElement Class.</para>| |
+|405|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2017_10_main.g.cs|<para>Defines the ReadonlyRecommended Class.</para>| |
+|406|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2017_3_main.g.cs|<para>Defines the TracksInfo Class.</para>| |
+|407|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2018_4_main.g.cs|<para>Defines the ClassificationOutcome Class.</para>| |
+|408|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2018_8_main.g.cs|<para>Defines the CommentUnknownAnchor Class.</para>| |
+|409|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2019_12_main.g.cs|<para>Defines the TaskHistoryDetails Class.</para>| |
+|410|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2019_9_main_command.g.cs|<para>Defines the CommentV2MonikerList Class.</para>| |
+|411|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2020_02_main.g.cs|<para>Defines the DesignerTagList Class.</para>| |
+|412|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2021_06_main.g.cs|<para>Defines the TaskHistoryDetails Class.</para>| |
+|413|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2022_03_main.g.cs|<para>Defines the Reactions Class.</para>| |
+|414|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2022_08_main.g.cs|<para>Defines the TaskDetails Class.</para>| |
+|415|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_powerpoint_2023_02_main.g.cs|<para>Defines the PlaceholderTypeExtension Class.</para>| |
+|416|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2009_9_main.g.cs|<para>Defines the ConditionalFormattings Class.</para>| |
+|417|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2010_11_ac.g.cs|<para>Defines the AbsolutePath Class.</para>| |
+|418|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2010_11_main.g.cs|<para>Defines the PivotCaches Class.</para>| |
+|419|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2011_1_ac.g.cs|<para>Defines the List Class.</para>| |
+|420|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2014_11_main.g.cs|<para>Defines the ModelTimeGroupings Class.</para>| |
+|421|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2014_revision.g.cs|<para>Defines the RevExHeaders Class.</para>| |
+|422|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2016_pivotdefaultlayout.g.cs|<para>Defines the PivotTableDefinition16 Class.</para>| |
+|423|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2017_dynamicarray.g.cs|<para>Defines the DynamicArrayProperties Class.</para>| |
+|424|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2017_richdata.g.cs|<para>Defines the RichValueBlock Class.</para>| |
+|425|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2017_richdata2.g.cs|<para>Defines the RichFilterColumn Class.</para>| |
+|426|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2018_calcfeatures.g.cs|<para>Defines the CalcFeatures Class.</para>| |
+|427|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2018_threadedcomments.g.cs|<para>Defines the PersonList Class.</para>| |
+|428|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2019_extlinksprops.g.cs|<para>Defines the ExternalLinksPr Class.</para>| |
+|429|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2019_namedsheetviews.g.cs|<para>Defines the NamedSheetViews Class.</para>| |
+|430|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2020_pivotNov2020.g.cs|<para>Defines the Xsdboolean Class.</para>| |
+|431|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2020_richdatawebimage.g.cs|<para>Defines the WebImagesSupportingRichData Class.</para>| |
+|432|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2020_richvaluerefresh.g.cs|<para>Defines the RichValueRefreshIntervals Class.</para>| |
+|433|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2020_threadedcomments2.g.cs|<para>Defines the XsdunsignedInt Class.</para>| |
+|434|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2021_extlinks2021.g.cs|<para>Defines the ExternalBookAlternateUrls Class.</para>| |
+|435|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2022_featurepropertybag.g.cs|<para>Defines the FeaturePropertyBags Class.</para>| |
+|436|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2022_pivotRichData.g.cs|<para>Defines the PivotCacheRichInfo Class.</para>| |
+|437|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2022_pivotVersionInfo.g.cs|<para>Defines the CacheVersionInfo Class.</para>| |
+|438|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2022_richvaluerel.g.cs|<para>Defines the RichValueRels Class.</para>| |
+|439|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2023_dataSourceVersioning.g.cs|<para>Defines the VersionInfo Class.</para>| |
+|440|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2023_externalCodeService.g.cs|<para>Defines the ExternalCodeService Class.</para>| |
+|441|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2023_msForms.g.cs|<para>Defines the Question Class.</para>| |
+|442|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2023_pivot2023Calculation.g.cs|<para>Defines the AggregationInfo Class.</para>| |
+|443|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2024_pivotAutoRefresh.g.cs|<para>Defines the Xsdboolean Class.</para>| |
+|444|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2024_pivotDynamicArrays.g.cs|<para>Defines the PivotCacheDynamicArray Class.</para>| |
+|445|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_spreadsheetml_2024_workbookCompatibilityVersion.g.cs|<para>Defines the Version Class.</para>| |
+|446|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_tasks_2019_documenttasks.g.cs|<para>Defines the Tasks Class.</para>| |
+|447|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_thememl_2012_main.g.cs|<para>Defines the ThemeFamily Class.</para>| |
+|448|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_webextensions_taskpanes_2010_11.g.cs|<para>Defines the Taskpanes Class.</para>| |
+|449|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_webextensions_webextension_2010_11.g.cs|<para>Defines the WebExtension Class.</para>| |
+|450|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2006_wordml.g.cs|<para>Defines the TemplateCommandGroup Class.</para>| |
+|451|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2010_wordml.g.cs|<para>Defines the RunConflictInsertion Class.</para>| |
+|452|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2010_wordprocessingCanvas.g.cs|<para>Defines the WordprocessingCanvas Class.</para>| |
+|453|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2010_wordprocessingDrawing.g.cs|<para>Defines the PercentagePositionHeightOffset Class.</para>| |
+|454|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2010_wordprocessingGroup.g.cs|<para>Defines the WordprocessingGroup Class.</para>| |
+|455|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2010_wordprocessingShape.g.cs|<para>Defines the WordprocessingShape Class.</para>| |
+|456|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2012_wordml.g.cs|<para>Defines the Color Class.</para>| |
+|457|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2012_wordprocessingDrawing.g.cs|<para>Defines the WebVideoProperty Class.</para>| |
+|458|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2015_wordml_symex.g.cs|<para>Defines the SymEx Class.</para>| |
+|459|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2016_wordml_cid.g.cs|<para>Defines the CommentsIds Class.</para>| |
+|460|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2018_wordml.g.cs|<para>Defines the Extension Class.</para>| |
+|461|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2018_wordml_cex.g.cs|<para>Defines the CommentsExtensible Class.</para>| |
+|462|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_microsoft_com_office_word_2020_oembed.g.cs|<para>Defines the OEmbed Class.</para>| |
+|463|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_chart.g.cs|<para>Number Format.</para>| |
+|464|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_chartDrawing.g.cs|<para>Relative Anchor Shape Size.</para>| |
+|465|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_compatibility.g.cs|<para>Legacy Drawing Object.</para>| |
+|466|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_diagram.g.cs|<para>Color Transform Definitions.</para>| |
+|467|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_lockedCanvas.g.cs|<para>Locked Canvas Container.</para>| |
+|468|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_main.g.cs|<para>Audio from CD.</para>| |
+|469|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_picture.g.cs|<para>Picture.</para>| |
+|470|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_spreadsheetDrawing.g.cs|<para>Two Cell Anchor Shape Size.</para>| |
+|471|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_drawingml_2006_wordprocessingDrawing.g.cs|<para>No Text Wrapping.</para>| |
+|472|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_officeDocument_2006_bibliography.g.cs|<para>Sources.</para>| |
+|473|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_officeDocument_2006_characteristics.g.cs|<para>Set of Additional Characteristics.</para>| |
+|474|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_officeDocument_2006_custom-properties.g.cs|<para>Custom File Properties.</para>| |
+|475|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_officeDocument_2006_customXml.g.cs|<para>Custom XML Data Properties.</para>| |
+|476|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_officeDocument_2006_docPropsVTypes.g.cs|<para>Variant.</para>| |
+|477|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_officeDocument_2006_extended-properties.g.cs|<para>Application Specific File Properties.</para>| |
+|478|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_officeDocument_2006_math.g.cs|<para>Script.</para>| |
+|479|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_presentationml_2006_main.g.cs|<para>All Slides.</para>| |
+|480|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_schemaLibrary_2006_main.g.cs|<para>Embedded Custom XML Schema Supplementary Data.</para>| |
+|481|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_spreadsheetml_2006_main.g.cs|<para>Extension.</para>| |
+|482|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/schemas_openxmlformats_org_wordprocessingml_2006_main.g.cs|<para>Table Cell Insertion.</para>| |
+|483|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/www_w3_org_2003_04_emma.g.cs|<para>Defines the DerivedFrom Class.</para>| |
+|484|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/www_w3_org_2003_InkML.g.cs|<para>Defines the Ink Class.</para>| |
+|485|./generated/DocumentFormat.OpenXml/DocumentFormat.OpenXml.Generator/DocumentFormat.OpenXml.Generator.OpenXmlGenerator/www_w3_org_XML_1998_namespace.g.cs|Defines the SpaceProcessingModeValues enumeration.| |
+|486|./samples/AnimatedModel3DExample/Program.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|487|./samples/DocumentTaskExample/Program.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|488|./samples/DocumentTaskExample/User.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|489|./samples/IsolatedStorageExceptionWorkaround/Program.Empty.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|490|./samples/IsolatedStorageExceptionWorkaround/Program.cs|When an application tries to use DocumentFormat.OpenXml in an AppDomain that does not have sufficient evidence, the following| |
+|491|./samples/Linq/SvgExample/GeneralTools.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|492|./samples/Linq/SvgExample/LinqToXmlTools.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|493|./samples/Linq/SvgExample/Program.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|494|./samples/Linq/SvgExample/StronglyTypedTools.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|495|./samples/NamedSheetView/Program.cs|Copyright (c) Microsoft. All rights reserved.| |
+|496|./samples/RichData/Program.cs|Copyright (c) Microsoft. All rights reserved.| |
+|497|./samples/SVGExample/Program.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|498|./samples/SunburstChartExample/Program.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|499|./samples/ThreadedCommentExample/Program.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|500|./samples/common/ExampleUtilities.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|501|./samples/common/PowerPointUtils.cs|Creates a new presentation document.| |
+|502|./src/DocumentFormat.OpenXml.Features/ElementEvents/ElementEventFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|503|./src/DocumentFormat.OpenXml.Features/ElementEvents/ElementEventFeatureExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|504|./src/DocumentFormat.OpenXml.Features/ElementEvents/IElementEventFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|505|./src/DocumentFormat.OpenXml.Features/ElementEvents/PartElementEventArgs.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|506|./src/DocumentFormat.OpenXml.Features/ISharedFeature.cs|A feature to create a composite feature if shared among multiple instances.| |
+|507|./src/DocumentFormat.OpenXml.Features/ParagraphId/IParagraphIdCollectionFeature.cs|Provides access to the paragraph id collection in a document.| |
+|508|./src/DocumentFormat.OpenXml.Features/ParagraphId/IParagraphIdGeneratorFeature.cs|A generator for paragraph id values that can ensure uniqueness if <see cref="IParagraphIdCollectionFeature"/> is registered.| |
+|509|./src/DocumentFormat.OpenXml.Features/ParagraphId/ParagraphIdCollectionFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|510|./src/DocumentFormat.OpenXml.Features/ParagraphId/ParagraphIdFeatureExtensions.cs|Extensions to add paragraph id generation to a document| |
+|511|./src/DocumentFormat.OpenXml.Features/ParagraphId/ParagraphIdGeneratorFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|512|./src/DocumentFormat.OpenXml.Features/ParagraphId/ParagraphIdOptions.cs|Options to declare how paragraph ids should be generated.| |
+|513|./src/DocumentFormat.OpenXml.Features/ParagraphId/SharedParagraphIdFeatureExtensions.cs|A collection of extensions that will add support for shared <see cref="IParagraphIdCollectionFeature"/> instances among multiple documents.| |
+|514|./src/DocumentFormat.OpenXml.Features/ParagraphId/WordDocumentParagraphIdCollectionFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|515|./src/DocumentFormat.OpenXml.Features/RandomNumberGenerator/IRandomNumberGeneratorFeature.cs|A feature to generate random numbers| |
+|516|./src/DocumentFormat.OpenXml.Features/RandomNumberGenerator/RandomNumberGeneratorFeatureExtensions.cs|Extensions to add a random number generator to a feature set.| |
+|517|./src/DocumentFormat.OpenXml.Features/System/Collections/Generic/CollectionsExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|518|./src/DocumentFormat.OpenXml.Features/System/Runtime/CompilerServices/IsExternalInit.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|519|./src/DocumentFormat.OpenXml.Features/TypedForwards.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|520|./src/DocumentFormat.OpenXml.Framework/AlternateContent.cs|Represents the mc:AlternateContent element of markup| |
+|521|./src/DocumentFormat.OpenXml.Framework/AlternateContentChoice.cs|Defines an mc:Choice element in mc:AlternateContent.| |
+|522|./src/DocumentFormat.OpenXml.Framework/AlternateContentFallback.cs|Defines a mc:Fallback element in mc:AlternateContent.| |
+|523|./src/DocumentFormat.OpenXml.Framework/AttributeAction.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|524|./src/DocumentFormat.OpenXml.Framework/Builder/IPackageBuilder{TPackage}.cs|A delegate for initializing a package.| |
+|525|./src/DocumentFormat.OpenXml.Framework/Builder/IPackageDocumentBuilder.cs|An interface that exposes ability to create a builder for <typeparamref name="TPackage"/>.| |
+|526|./src/DocumentFormat.OpenXml.Framework/Builder/IPackageFactory.cs|Defines a factory to create a <typeparamref name="TPackage"/>.| |
+|527|./src/DocumentFormat.OpenXml.Framework/Builder/OpenXmlPackageBuilder.cs|Copyright (c) Microsoft. All rights reserved.| |
+|528|./src/DocumentFormat.OpenXml.Framework/Builder/OpenXmlPackageBuilderExtensions.cs|A collection of extension methods for opening packages| |
+|529|./src/DocumentFormat.OpenXml.Framework/Builder/PackageOpenMode.cs|An enum that describes how a package is going to be opened| |
+|530|./src/DocumentFormat.OpenXml.Framework/Builder/SchemaTrackingExtensions.cs|A collection of extension methods to track schema usage| |
+|531|./src/DocumentFormat.OpenXml.Framework/Builder/StorageBuilderExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|532|./src/DocumentFormat.OpenXml.Framework/Builder/TemplateBuilderExtensions.cs|A collection of extensions to add a template as part of the <see cref="IPackageBuilder{TPackage}"/>.| |
+|533|./src/DocumentFormat.OpenXml.Framework/ElementAction.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|534|./src/DocumentFormat.OpenXml.Framework/ElementEventArgs.cs|Represents arguments for element events.| |
+|535|./src/DocumentFormat.OpenXml.Framework/ElementState.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|536|./src/DocumentFormat.OpenXml.Framework/EnumerableExtensions.cs|Similar to <see cref="Enumerable.FirstOrDefault{TSource}(IEnumerable{TSource})"/> but will also verify that at most there is one.| |
+|537|./src/DocumentFormat.OpenXml.Framework/Equality/OpenXmlElementComparers.cs|Equality comparer for determining value equality for <see cref="OpenXmlElement"/>.| |
+|538|./src/DocumentFormat.OpenXml.Framework/Equality/OpenXmlElementEqualityComparer.cs|Gets the options regulating how equality is defined.| |
+|539|./src/DocumentFormat.OpenXml.Framework/Equality/OpenXmlElementEqualityOptions.cs|Options defining the behavior of equality for <see cref="OpenXmlElement"/>.| |
+|540|./src/DocumentFormat.OpenXml.Framework/ExperimentalApis.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|541|./src/DocumentFormat.OpenXml.Framework/Features/AnnotationsFeature.cs|Adds an object to the annotation list of this collection.| |
+|542|./src/DocumentFormat.OpenXml.Framework/Features/DefaultFeatures.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|543|./src/DocumentFormat.OpenXml.Framework/Features/DisposableFeatureExtensions.cs|Extensions for using <see cref="IDisposableFeature"/>| |
+|544|./src/DocumentFormat.OpenXml.Framework/Features/EventType.cs|Type of event used for change notification.| |
+|545|./src/DocumentFormat.OpenXml.Framework/Features/FeatureCollection.cs|Represents a collection of features.| |
+|546|./src/DocumentFormat.OpenXml.Framework/Features/FeatureContainer.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|547|./src/DocumentFormat.OpenXml.Framework/Features/FeatureEventArgs.cs|Holder for feature event args.| |
+|548|./src/DocumentFormat.OpenXml.Framework/Features/FeatureEvent{TArg}.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|549|./src/DocumentFormat.OpenXml.Framework/Features/FeatureExtensions.cs|Methods to help with using <see cref="IFeatureCollection"/>.| |
+|550|./src/DocumentFormat.OpenXml.Framework/Features/FilePackageFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|551|./src/DocumentFormat.OpenXml.Framework/Features/IApplicationTypeFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|552|./src/DocumentFormat.OpenXml.Framework/Features/IContainerDisposableFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|553|./src/DocumentFormat.OpenXml.Framework/Features/IContentTypeFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|554|./src/DocumentFormat.OpenXml.Framework/Features/IDataPartsFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|555|./src/DocumentFormat.OpenXml.Framework/Features/IDisposableFeature.cs|Feature to track items to dispose when the containing package or part is closed.| |
+|556|./src/DocumentFormat.OpenXml.Framework/Features/IDocumentTypeFeature.cs|Feature interface that defines the type of a document and allows for changing it.| |
+|557|./src/DocumentFormat.OpenXml.Framework/Features/IFeatureCollection.cs|Represents a collection of features.| |
+|558|./src/DocumentFormat.OpenXml.Framework/Features/IFeatureEvent.cs|Interface for general feature eventing.| |
+|559|./src/DocumentFormat.OpenXml.Framework/Features/IKnownDataPartFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|560|./src/DocumentFormat.OpenXml.Framework/Features/ILockFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|561|./src/DocumentFormat.OpenXml.Framework/Features/IMainPartFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|562|./src/DocumentFormat.OpenXml.Framework/Features/IOpenXmlNamespaceResolver.cs|Attempts to get the Transitional equivalent namespace.| |
+|563|./src/DocumentFormat.OpenXml.Framework/Features/IPackageEventsFeature.cs|A feature to track events around the package.| |
+|564|./src/DocumentFormat.OpenXml.Framework/Features/IPackageFactoryFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|565|./src/DocumentFormat.OpenXml.Framework/Features/IPackageFeature.cs|A feature to access the backing <see cref="IPackage"/> data.| |
+|566|./src/DocumentFormat.OpenXml.Framework/Features/IPackageInitializer.cs|An initializer for a package.| |
+|567|./src/DocumentFormat.OpenXml.Framework/Features/IPackagePartFeature.cs|A feature to access the current package part.| |
+|568|./src/DocumentFormat.OpenXml.Framework/Features/IPackageStreamFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|569|./src/DocumentFormat.OpenXml.Framework/Features/IPartConstraintFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|570|./src/DocumentFormat.OpenXml.Framework/Features/IPartEventsFeature.cs|A feature to track events around parts.| |
+|571|./src/DocumentFormat.OpenXml.Framework/Features/IPartExtensionFeature.cs|A feature that defines what extensions are used for a given part content type| |
+|572|./src/DocumentFormat.OpenXml.Framework/Features/IPartFactoryFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|573|./src/DocumentFormat.OpenXml.Framework/Features/IPartRelationshipsFeature.cs|Adds a part to the relationship collection. If an <paramref name="id"/> is provided, it will be used, otherwise a random id will be generated.| |
+|574|./src/DocumentFormat.OpenXml.Framework/Features/IPartRootEventsFeature.cs|A feature to track events around parts.| |
+|575|./src/DocumentFormat.OpenXml.Framework/Features/IPartUriFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|576|./src/DocumentFormat.OpenXml.Framework/Features/IPartsFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|577|./src/DocumentFormat.OpenXml.Framework/Features/IProgrammaticIdentifierFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|578|./src/DocumentFormat.OpenXml.Framework/Features/IRaiseFeatureEvent.cs|Interface to raise events for <see cref="IFeatureEvent{TArg}"/>.| |
+|579|./src/DocumentFormat.OpenXml.Framework/Features/IReferenceRelationshipsFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|580|./src/DocumentFormat.OpenXml.Framework/Features/IRelationshipFilterFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|581|./src/DocumentFormat.OpenXml.Framework/Features/IRootElementFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|582|./src/DocumentFormat.OpenXml.Framework/Features/ISaveFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|583|./src/DocumentFormat.OpenXml.Framework/Features/ISchemaTrackingFeature.cs|Feature to describe the schema elements that have been used.| |
+|584|./src/DocumentFormat.OpenXml.Framework/Features/IStrictNamespaceFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|585|./src/DocumentFormat.OpenXml.Framework/Features/ITargetFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|586|./src/DocumentFormat.OpenXml.Framework/Features/ITypedPartFactoryFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|587|./src/DocumentFormat.OpenXml.Framework/Features/OpenXmlNamespaceResolver.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|588|./src/DocumentFormat.OpenXml.Framework/Features/PackageCapabilities.cs|Values to query the capabilities of a package.| |
+|589|./src/DocumentFormat.OpenXml.Framework/Features/PackageEventExtensions.cs|Extensions to add events around lifecycle.| |
+|590|./src/DocumentFormat.OpenXml.Framework/Features/PackageFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|591|./src/DocumentFormat.OpenXml.Framework/Features/PackageFeatureBase.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|592|./src/DocumentFormat.OpenXml.Framework/Features/PackagePartFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|593|./src/DocumentFormat.OpenXml.Framework/Features/PartEventFeatureExtensions.cs|Extensions to add events around parts.| |
+|594|./src/DocumentFormat.OpenXml.Framework/Features/PartRootEventExtensions.cs|Extensions to add events around part roots.| |
+|595|./src/DocumentFormat.OpenXml.Framework/Features/RelationshipFilterExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|596|./src/DocumentFormat.OpenXml.Framework/Features/StreamPackageFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|597|./src/DocumentFormat.OpenXml.Framework/Features/StrictNamespaceExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|598|./src/DocumentFormat.OpenXml.Framework/FileFormatVersionExtensions.cs|Determines whether the supplied version is within the known set of versions| |
+|599|./src/DocumentFormat.OpenXml.Framework/FileFormatVersions.cs|Defines the Office Open XML file format version.| |
+|600|./src/DocumentFormat.OpenXml.Framework/Framework/ApplicationType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|601|./src/DocumentFormat.OpenXml.Framework/Framework/Cached.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|602|./src/DocumentFormat.OpenXml.Framework/Framework/ContentTypeAttribute.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|603|./src/DocumentFormat.OpenXml.Framework/Framework/DelegatingStream.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|604|./src/DocumentFormat.OpenXml.Framework/Framework/IFixedContentTypePart.cs|Called from constructors of derived parts to initialize the IFixedContentTypePart interface. All derived parts must be parts that have fixed content type.| |
+|605|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/AttributeCollection.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|606|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/AttributeMetadata.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|607|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/ElementFactory.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|608|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/ElementFactoryCollection.cs|A lookup that identifies properties on an <see cref="OpenXmlElement"/> and caches the schema information| |
+|609|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/ElementMetadata.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|610|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/ElementMetadataFactoryFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|611|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/ElementState.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|612|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/IElementMetadata.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|613|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/IElementMetadataFactoryFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|614|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/IMetadataBuilder{T}.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|615|./src/DocumentFormat.OpenXml.Framework/Framework/Metadata/ValidatorBuilder.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|616|./src/DocumentFormat.OpenXml.Framework/Framework/NamespaceExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|617|./src/DocumentFormat.OpenXml.Framework/Framework/OpenXmlNamespace.cs|A structure that defines a namespace.| |
+|618|./src/DocumentFormat.OpenXml.Framework/Framework/OpenXmlQualifiedName.cs|A structure that defines a fully qualified name with a namespace and name.| |
+|619|./src/DocumentFormat.OpenXml.Framework/Framework/OpenXmlSchemaType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|620|./src/DocumentFormat.OpenXml.Framework/Framework/PartConstraintRule.cs|Gets the relationship type.| |
+|621|./src/DocumentFormat.OpenXml.Framework/Framework/PrefixName.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|622|./src/DocumentFormat.OpenXml.Framework/Framework/ReadOnlyArray.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|623|./src/DocumentFormat.OpenXml.Framework/Framework/ReadOnlyStream.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|624|./src/DocumentFormat.OpenXml.Framework/Framework/RelationshipTypeAttribute.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|625|./src/DocumentFormat.OpenXml.Framework/Framework/ReservedElementTypeIds.cs|Test whether the element is a strong typed element - the class is generated by CodeGen.| |
+|626|./src/DocumentFormat.OpenXml.Framework/Framework/Schema/CompiledParticle.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|627|./src/DocumentFormat.OpenXml.Framework/Framework/Schema/LookupItem.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|628|./src/DocumentFormat.OpenXml.Framework/Framework/Schema/ParticleCollection.cs|This struct represents a way to access elements in a structured way based on its compiled particle.| |
+|629|./src/DocumentFormat.OpenXml.Framework/Framework/Schema/ParticleCompiler.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|630|./src/DocumentFormat.OpenXml.Framework/Framework/Schema/ParticleExtensions.cs|These extensions are set up so that it is easier to test a <see cref="CompiledParticle"/> against an <see cref="OpenXmlCompositeElement"/>.| |
+|631|./src/DocumentFormat.OpenXml.Framework/Framework/Schema/ParticlePath.cs|Checks if two <see cref="ParticlePath"/> instances are the same. They may not have the exact same sequence, but if they are replaceable, then they are equal.| |
+|632|./src/DocumentFormat.OpenXml.Framework/Framework/Schema/ParticlePathItem.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|633|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/EnumValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|634|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/INameProvider.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|635|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/IValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|636|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/ListValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|637|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/NameProviderValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|638|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/NumberValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|639|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/OfficeVersionValidator.cs|Gets the Office version of the available property.| |
+|640|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/RequiredValidator.cs|Describes a required item.| |
+|641|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/SimpleTypeValidator{TSimpleType}.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|642|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/StringValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|643|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/UnionValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|644|./src/DocumentFormat.OpenXml.Framework/Framework/Validation/VersionedValidator.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|645|./src/DocumentFormat.OpenXml.Framework/FrameworkExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|646|./src/DocumentFormat.OpenXml.Framework/InvalidMCContentException.cs|The exception that is thrown for Markup Compatibility content errors.| |
+|647|./src/DocumentFormat.OpenXml.Framework/MCConsts.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|648|./src/DocumentFormat.OpenXml.Framework/MCContext.cs|This method is for MC validation use. Only push Ignorable and ProcessContent.| |
+|649|./src/DocumentFormat.OpenXml.Framework/MarkupCompatibilityAttributes.cs|Defines the Markup Compatibility Attributes.| |
+|650|./src/DocumentFormat.OpenXml.Framework/MiscAttrContainer.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|651|./src/DocumentFormat.OpenXml.Framework/NamespaceNotUnderstandException.cs|The exception that is thrown for Markup Compatibility content errors.| |
+|652|./src/DocumentFormat.OpenXml.Framework/OpenXmlAttribute.cs|Represents an Open XML attribute.| |
+|653|./src/DocumentFormat.OpenXml.Framework/OpenXmlCompositeElement.cs|Represents the base class for composite elements.| |
+|654|./src/DocumentFormat.OpenXml.Framework/OpenXmlDomReader.cs|Represents the Open XML document reader class.| |
+|655|./src/DocumentFormat.OpenXml.Framework/OpenXmlElement.cs|Represents a base class that all elements in an Office Open XML document derive from.| |
+|656|./src/DocumentFormat.OpenXml.Framework/OpenXmlElementContext.cs|Represents the OpenXml loading context.| |
+|657|./src/DocumentFormat.OpenXml.Framework/OpenXmlElementExtensionMethods.cs|Static class to hold extension methods for OpenXmlElement.| |
+|658|./src/DocumentFormat.OpenXml.Framework/OpenXmlElementFunctionalExtensions.cs|Provides extension methods for pure functional transformations.| |
+|659|./src/DocumentFormat.OpenXml.Framework/OpenXmlElementList.cs|A struct that helps enumerate the child elements of an <see cref="OpenXmlElement"/>| |
+|660|./src/DocumentFormat.OpenXml.Framework/OpenXmlLeafElement.cs|Represents the base class from which leaf elements are derived.| |
+|661|./src/DocumentFormat.OpenXml.Framework/OpenXmlLeafTextElement.cs|Represents the base class from which leaf elements that have text are derived.| |
+|662|./src/DocumentFormat.OpenXml.Framework/OpenXmlLoadMode.cs|OpenXmlLoadMode - load mode, default is Lazy| |
+|663|./src/DocumentFormat.OpenXml.Framework/OpenXmlMiscNode.cs|Represents an Open XML non element node (i.e. PT, Comments, Entity, Notation, XmlDeclaration).| |
+|664|./src/DocumentFormat.OpenXml.Framework/OpenXmlPartReader.cs|Represents the Open XML part reader class.| |
+|665|./src/DocumentFormat.OpenXml.Framework/OpenXmlPartReaderOptions.cs|A collection of options for reading part information.| |
+|666|./src/DocumentFormat.OpenXml.Framework/OpenXmlPartRootElement.cs|Represents a base class for all root elements.| |
+|667|./src/DocumentFormat.OpenXml.Framework/OpenXmlPartWriter.cs|Defines the OpenXmlPartWriter.| |
+|668|./src/DocumentFormat.OpenXml.Framework/OpenXmlPartWriterSettings.cs|Settings for the <see cref="OpenXmlPartWriter" /> .| |
+|669|./src/DocumentFormat.OpenXml.Framework/OpenXmlReader.cs|Represents the Open XML reader class.| |
+|670|./src/DocumentFormat.OpenXml.Framework/OpenXmlUnknownElement.cs|Represents elements that are not defined in the Office Open XML ECMA standard.| |
+|671|./src/DocumentFormat.OpenXml.Framework/OpenXmlUnknownElementExtensions.cs|Extension methods for managing unknown elements| |
+|672|./src/DocumentFormat.OpenXml.Framework/OpenXmlWriter.cs|Defines the OpenXmlWriter.| |
+|673|./src/DocumentFormat.OpenXml.Framework/Packaging/AudioReferenceRelationship.cs|Represents an internal audio reference relationship to a MediaDataPart element.| |
+|674|./src/DocumentFormat.OpenXml.Framework/Packaging/Builder/DelegatingPackageFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|675|./src/DocumentFormat.OpenXml.Framework/Packaging/Builder/DelegatingPackagePart.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|676|./src/DocumentFormat.OpenXml.Framework/Packaging/Builder/PackageRelationshipBuilder.cs|A mutable instance of a package relationship used while building the final relationship| |
+|677|./src/DocumentFormat.OpenXml.Framework/Packaging/Builder/SavePackageExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|678|./src/DocumentFormat.OpenXml.Framework/Packaging/CloneableExtensions.cs|Extensions to enable package cloning.| |
+|679|./src/DocumentFormat.OpenXml.Framework/Packaging/CompatibilityLevel.cs|An enum that describes the version to keep compatibility with.| |
+|680|./src/DocumentFormat.OpenXml.Framework/Packaging/DataPart.cs|Represents the type of part referenced by a <see cref="DataPartReferenceRelationship"/>.| |
+|681|./src/DocumentFormat.OpenXml.Framework/Packaging/DataPartReferenceRelationship.cs|Represents an internal reference relationship to a DataPart element.| |
+|682|./src/DocumentFormat.OpenXml.Framework/Packaging/ExtendedPart.cs|Defines a class for all extended parts (Application specific part).| |
+|683|./src/DocumentFormat.OpenXml.Framework/Packaging/ExternalRelationship.cs|Represents an external relationship.| |
+|684|./src/DocumentFormat.OpenXml.Framework/Packaging/FeatureCollectionBase.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|685|./src/DocumentFormat.OpenXml.Framework/Packaging/FeatureCollectionDebugView.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|686|./src/DocumentFormat.OpenXml.Framework/Packaging/FlatOpcExtensions.cs|Extensions to convert to and from FlatOpc| |
+|687|./src/DocumentFormat.OpenXml.Framework/Packaging/HyperlinkRelationship.cs|Represents a hyperlink relationship.| |
+|688|./src/DocumentFormat.OpenXml.Framework/Packaging/IPackage.cs|An abstraction similar to <see cref="System.IO.Packaging.Package"/> that allows for pass through implementations| |
+|689|./src/DocumentFormat.OpenXml.Framework/Packaging/IPackagePart.cs|An abstraction for <see cref="System.IO.Packaging.PackagePart"/> that is easier to override.| |
+|690|./src/DocumentFormat.OpenXml.Framework/Packaging/IPackageProperties.cs|An abstraction of package properties, similar to <see cref="System.IO.Packaging.PackageProperties"/>.| |
+|691|./src/DocumentFormat.OpenXml.Framework/Packaging/IPackageRelationship.cs|An interface that defines the relationship between a source and a target part. Similar to <see cref="PackageRelationship"/> but allows full overriding.| |
+|692|./src/DocumentFormat.OpenXml.Framework/Packaging/IRelationshipCollection.cs|A collection of relationships for a <see cref="IPackage"/> of <see cref="IPackagePart"/>.| |
+|693|./src/DocumentFormat.OpenXml.Framework/Packaging/ISupportedRelationship.cs|Defines the interface for tagging a part that can add extensible parts.| |
+|694|./src/DocumentFormat.OpenXml.Framework/Packaging/IdPartPair.cs|Represents a (RelationshipId, OpenXmlPart) pair.| |
+|695|./src/DocumentFormat.OpenXml.Framework/Packaging/MarkupCompatibilityProcessMode.cs|Specifies the mode in which to process the markup compatibility tags in the document.| |
+|696|./src/DocumentFormat.OpenXml.Framework/Packaging/MarkupCompatibilityProcessSettings.cs|Represents markup compatibility processing settings.| |
+|697|./src/DocumentFormat.OpenXml.Framework/Packaging/MediaDataPart.cs|Represents a media (Audio, Video) data part in the document.| |
+|698|./src/DocumentFormat.OpenXml.Framework/Packaging/MediaDataPartType.cs|Defines part media types.| |
+|699|./src/DocumentFormat.OpenXml.Framework/Packaging/MediaDataPartTypeInfo.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|700|./src/DocumentFormat.OpenXml.Framework/Packaging/MediaReferenceRelationship.cs|Represents an internal media reference relationship to a MediaDataPart element.| |
+|701|./src/DocumentFormat.OpenXml.Framework/Packaging/OpenSettings.cs|Represents the settings when opening a document.| |
+|702|./src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackage.cs|Represents a base class for strong typed Open XML document classes.| |
+|703|./src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackageException.cs|Represents an Open XML package exception class for errors.| |
+|704|./src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackageExtensions.cs|Extensions for <see cref="OpenXmlPackage"/> type.| |
+|705|./src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPackageValidationResult.cs|Gets or sets the message string of the event.| |
+|706|./src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPart.cs|Represents an abstract base class for all OpenXml parts.| |
+|707|./src/DocumentFormat.OpenXml.Framework/Packaging/OpenXmlPartContainer.cs|Defines the base class for OpenXmlPackage and OpenXmlPart.| |
+|708|./src/DocumentFormat.OpenXml.Framework/Packaging/PackageAbstractionExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|709|./src/DocumentFormat.OpenXml.Framework/Packaging/PackageExtensions.cs|Extensions to retrieve package details.| |
+|710|./src/DocumentFormat.OpenXml.Framework/Packaging/PackageFeatureCollection.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|711|./src/DocumentFormat.OpenXml.Framework/Packaging/PackagePartUriHelper.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|712|./src/DocumentFormat.OpenXml.Framework/Packaging/PackageUriHandlingExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|713|./src/DocumentFormat.OpenXml.Framework/Packaging/PartExtensionProvider.cs|Defines a provider which maintains a dictionary where the key is the content type and the value is a part extension.| |
+|714|./src/DocumentFormat.OpenXml.Framework/Packaging/PartFeatureCollection.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|715|./src/DocumentFormat.OpenXml.Framework/Packaging/PartRelationshipsFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|716|./src/DocumentFormat.OpenXml.Framework/Packaging/PartTypeInfo.cs|Defines information used in creating a new part.| |
+|717|./src/DocumentFormat.OpenXml.Framework/Packaging/PartUriHelper.cs|List of contentTypes that need to have a '1' appended to the name for the first item in the package.| |
+|718|./src/DocumentFormat.OpenXml.Framework/Packaging/ReferenceRelationship.cs|Defines a reference relationship. A reference relationship can be internal or external.| |
+|719|./src/DocumentFormat.OpenXml.Framework/Packaging/VideoReferenceRelationship.cs|Represents an internal video reference relationship to a MediaDataPart element.| |
+|720|./src/DocumentFormat.OpenXml.Framework/Packaging/WriteableStreamExtensions.cs|Attempts to replace the underlying stream so that we can modify it even in readonly situations via a copy| |
+|721|./src/DocumentFormat.OpenXml.Framework/Properties/Properties.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|722|./src/DocumentFormat.OpenXml.Framework/Resources/ExceptionMessages.Designer.cs|A strongly-typed resource class, for looking up localized strings, etc.| |
+|723|./src/DocumentFormat.OpenXml.Framework/Resources/SR.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|724|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/Base64BinaryValue.cs|Represents the xsd:base64Binary value for attributes.| |
+|725|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/BooleanValue.cs|Represents the <see cref="bool"/> value for attributes.| |
+|726|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/ByteValue.cs|Represents the byte value for attributes.| |
+|727|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/DateTimeValue.cs|Represents the <see cref="DateTime"/> value for attributes.| |
+|728|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/DecimalValue.cs|Represents the decimal value for attributes.| |
+|729|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/DoubleValue.cs|Represents the double value for attributes.| |
+|730|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/EnumValue.cs|Represents the enum value for attributes.| |
+|731|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/HexBinaryValue.cs|Represent the xsd:hexBinary value for attributes.| |
+|732|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/HexStringFactory.cs|A factory of hex strings.| |
+|733|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/IEnumValue.cs|A definition of an OpenXml enum value| |
+|734|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/IEnumValueFactory.cs|Factory to create a new enum value of the specified type.| |
+|735|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/Int16Value.cs|Represents the <see cref="short"/> value for attributes.| |
+|736|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/Int32Value.cs|Represents the <see cref="int"/> value for attributes.| |
+|737|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/Int64Value.cs|Represents the <see cref="long"/> value for attributes.| |
+|738|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/IntegerValue.cs|Represents the xsd:integer value for attributes.| |
+|739|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/ListValue.cs|Represents the list value attributes (xsd:list).| |
+|740|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/OnOffValue.cs|Defines an <see cref="OnOffValue"/> data type for attributes that have enum values that are <see cref="bool"/> values that represent: 'true' or 'false', 'on' or 'off', or '0' or '1'.| |
+|741|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/OpenXmlComparableSimpleReference.cs|Represents a comparable and equatable reference.| |
+|742|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/OpenXmlComparableSimpleValue.cs|Represents a comparable and equatable value.| |
+|743|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/OpenXmlSimpleType.cs|Represents the abstract base class for all simple types that are used in attributes.| |
+|744|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/OpenXmlSimpleTypeExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|745|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/OpenXmlSimpleValue.cs|Represents a generic value for simple value types (such as <see cref="int"/> , <see cref="uint"/>, <see cref="byte"/>, etc).| |
+|746|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/SByteValue.cs|Represents the <see cref="sbyte"/> value for attributes.| |
+|747|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/SingleValue.cs|Represents the <see cref="float"/> value for attributes.| |
+|748|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/StringValue.cs|Represents the string value for attributes.| |
+|749|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/TrueFalseBlankValue.cs|Represents the data type for attributes that have enum values that are <see cref="bool"/> values that represent 't' or 'f', or 'true' or 'false'.| |
+|750|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/TrueFalseValue.cs|Represents the data type for attributes that have enum values that are <see cref="bool"/> values that represent 't' or 'f', or 'true' or 'false'.| |
+|751|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/UInt16Value.cs|Represents the <see cref="ushort"/> value for attributes.| |
+|752|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/UInt32Value.cs|Represents the <see cref="uint"/> value for attributes.| |
+|753|./src/DocumentFormat.OpenXml.Framework/SimpleTypes/UInt64Value.cs|Represents the <see cref="ulong"/> value for attributes.| |
+|754|./src/DocumentFormat.OpenXml.Framework/System/DictionaryExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|755|./src/DocumentFormat.OpenXml.Framework/System/EnumHelper.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|756|./src/DocumentFormat.OpenXml.Framework/System/StringExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|757|./src/DocumentFormat.OpenXml.Framework/System/UriHelper.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|758|./src/DocumentFormat.OpenXml.Framework/Validation/DocumentValidator.cs|DocumentValidator - defines a base class for document validator.| |
+|759|./src/DocumentFormat.OpenXml.Framework/Validation/OpenXmlValidator.cs|Defines the OpenXmlValidator.| |
+|760|./src/DocumentFormat.OpenXml.Framework/Validation/PackageValidator.cs|Defines the base class for OpenXmlPackage and OpenXmlPart.| |
+|761|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/AllParticleValidator.cs|All particle validator.| |
+|762|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/AlternateContentValidator.cs|Validator for MarkupCompatibility feature - AlternateContent.| |
+|763|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/AnyParticle.cs|Particle constraint data for particle which type is ParticleType.Any.| |
+|764|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/AnyParticleValidator.cs|Any particle validator.| |
+|765|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ChoiceParticleValidator.cs|Choice particle validator.| |
+|766|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/CompatibilityRuleAttributesValidator.cs|Compatibility-Rule Attributes| |
+|767|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/CompositeParticle.cs|Particle constraint for sequence, choice, all, and group.| |
+|768|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/CompositeParticleValidator.cs|Base class for composite particle - sequence, choice, all, group. Defines some common functions.| |
+|769|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ElementParticle.cs|Particle constraint data for particle which type is ParticleType.Element.| |
+|770|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ExpectedChildren.cs|Hold expected children for error reporting.| |
+|771|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/GroupParticleValidator.cs|Group particle validator.| |
+|772|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/IParticleValidator.cs|Defines methods to validate particles.| |
+|773|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/OpenXmlElementExtensionMethods.cs|Static class to hold extension methods for OpenXmlElement.| |
+|774|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ParticleConstraint.cs|A constraint data item for complex type.| |
+|775|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ParticleMatch.cs|Particle match result.| |
+|776|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ParticleMatchInfo.cs|Information about particle match.| |
+|777|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ParticleType.cs|Particle type.| |
+|778|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ParticleValidator.cs|Base class for particle validator.| |
+|779|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/Restrictions/AnyUriRestriction.cs|AnyURI (xsd:anyURI) based simple type constraint.| |
+|780|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/Restrictions/QnameRestriction.cs|QName (xsd:QName) based simple type constraint.| |
+|781|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/Restrictions/TokenRestriction.cs|Token (xsd:token) based simple type constraint.| |
+|782|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/SchemaTypeValidator.cs|Validate an OpenXmlElement based on the schema.| |
+|783|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/SequenceParticleValidator.cs|Sequence particle validator.| |
+|784|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/ValidationContextExtension.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|785|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/XsdAny.cs|##any - Elements from any namespace can be present.| |
+|786|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/XsdAnyExtensions.cs|Get corresponding namespace string for Any, Other, Local and TargetNamespace.| |
+|787|./src/DocumentFormat.OpenXml.Framework/Validation/Schema/XsdType.cs|All simple types built in to xml schema.| |
+|788|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeAbsentConditionToNonValue.cs|1.15 attribute should be absent if another attribute not equals some value| |
+|789|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeAbsentConditionToValue.cs|1.14 attribute should be absent if another attribute equals some value| |
+|790|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeCannotOmitConstraint.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|791|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeMinMaxConstraint.cs|One attribute value must no bigger than another's.| |
+|792|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeMutualExclusive.cs|1.16 only one of a group attributes can exist| |
+|793|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributePairConstraint.cs|Two attributes of one element must appear as a pair.| |
+|794|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeRequiredConditionToValue.cs|1.18 attribute is required if another attribute equals some value| |
+|795|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeValueConditionToAnother.cs|1.19 attribute should be of some value if another attribute is of some value| |
+|796|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeValueLengthConstraint.cs|1.12 Attribute value length must be in specified range.| |
+|797|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeValueLessEqualToAnother.cs|1.17 value of one attribute must be less than or equal another's| |
+|798|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeValuePatternConstraint.cs|1.2 Attribute value should follow specified regular expression| |
+|799|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeValueRangeConstraint.cs|1.3 Attribute value is a number, it must (or must not) in range of min to max.| |
+|800|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/AttributeValueSetConstraint.cs|1.4/1.10 Attribute value must (or must not) in specified value set.| |
+|801|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/IndexReferenceConstraint.cs|3.2 Class for package-level constraint "indexed element must exist".| |
+|802|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/ParentTypeConstraint.cs|Element's parent must be/not be of a specified type| |
+|803|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/ReferenceExistConstraint.cs|3.1 Class for package-level constraint "referenced element must exist".| |
+|804|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/RelationshipExistConstraint.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|805|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/RelationshipTypeConstraint.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|806|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/SemanticConstraint.cs|Base class for each semantic constraint category.| |
+|807|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/SemanticValidationLevel.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|808|./src/DocumentFormat.OpenXml.Framework/Validation/Semantic/UniqueAttributeValueConstraint.cs|2.3 Element's attribute value should be unique within specified type of element.| |
+|809|./src/DocumentFormat.OpenXml.Framework/Validation/StateManager.cs|Method to get or create a cached value. To minimize allocations, the key should track everything that is| |
+|810|./src/DocumentFormat.OpenXml.Framework/Validation/TraversalOptions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|811|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationCache.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|812|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationContext.cs|Gets target file format.| |
+|813|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationElement.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|814|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationErrorEventArgs.cs|An implementation of <see cref="EventArgs"/> for validation error event.| |
+|815|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationErrorInfo.cs|Defines the ValidationErrorInfo.| |
+|816|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationErrorType.cs|The type of the validation error.| |
+|817|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationResources.Designer.cs|A strongly-typed resource class, for looking up localized strings, etc.| |
+|818|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationSettings.cs|Settings for validation.| |
+|819|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationStack.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|820|./src/DocumentFormat.OpenXml.Framework/Validation/ValidationTraverser.cs|Enumerate all the descendants elements of this element and do validating.| |
+|821|./src/DocumentFormat.OpenXml.Framework/XmlConvertingReader.cs|Defines the XmlConvertingReader - This XmlReader tries to replace the Strict namespaces with equivalent Transitional namespaces.| |
+|822|./src/DocumentFormat.OpenXml.Framework/XmlConvertingReaderFactory.cs|Defines the XmlConvertingReaderFactory.| |
+|823|./src/DocumentFormat.OpenXml.Framework/XmlDOMTextWriter.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|824|./src/DocumentFormat.OpenXml.Framework/XmlLineInfo.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|825|./src/DocumentFormat.OpenXml.Framework/XmlPath.cs|Defines XPath like information for OpenXmlElement.| |
+|826|./src/DocumentFormat.OpenXml.Linq/Feature/IOpenXmlPartRootXElementFeature.cs|Feature to allow access to <see cref="XElement"/> representation of a <see cref="OpenXmlPart"/>.| |
+|827|./src/DocumentFormat.OpenXml.Linq/Feature/OpenXmlPartRootXElementExtensions.cs|Extensions to access the <see cref="XElement"/> representation of an <see cref="OpenXmlPart"/>'s| |
+|828|./src/DocumentFormat.OpenXml.Linq/Feature/OpenXmlPartRootXElementFeature.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|829|./src/DocumentFormat.OpenXml.Linq/MC.cs|Declares XNamespace and XName fields for the xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" namespace.| |
+|830|./src/DocumentFormat.OpenXml.Linq/Presentation/P188.cs|Represents the p188:ext XML element.| |
+|831|./src/DocumentFormat.OpenXml/Packaging/AlternativeFormatImportPartType.cs|Defines AlternativeFormatImportPartType - types of AlternativeFormatImportPart.| |
+|832|./src/DocumentFormat.OpenXml/Packaging/CoreFilePropertiesPart.cs|Defines the CoreFilePropertiesPart| |
+|833|./src/DocumentFormat.OpenXml/Packaging/CustomPropertyPartType.cs|Defines CustomPropertyPartType - types of CustomPropertyPart.| |
+|834|./src/DocumentFormat.OpenXml/Packaging/CustomUIPart.cs|Defines CustomUiPart. The CustomUiPart served as the base class of RibbonExtensibilityPart and QuickAccessToolbarCustomizationsPart.| |
+|835|./src/DocumentFormat.OpenXml/Packaging/CustomXmlPartType.cs|Defines CustomXmlPartType - types of CustomXmlPart.| |
+|836|./src/DocumentFormat.OpenXml/Packaging/EmbeddedControlPersistenceBinaryDataPartType.cs|Defines EmbeddedControlPersistenceBinaryDataPartType - types of EmbeddedControlPart.| |
+|837|./src/DocumentFormat.OpenXml/Packaging/EmbeddedControlPersistencePartType.cs|Defines EmbeddedControlPersistencePartType - types of EmbeddedControlPart.| |
+|838|./src/DocumentFormat.OpenXml/Packaging/EmbeddedObjectPartType.cs|Defines EmbeddedPackagePartType - types of EmbeddedPackagePart.| |
+|839|./src/DocumentFormat.OpenXml/Packaging/EmbeddedPackagePartType.cs|Defines EmbeddedPackagePartType - types of EmbeddedPackagePart.| |
+|840|./src/DocumentFormat.OpenXml/Packaging/FontPartType.cs|Defines FontPartType - types of FontPart.| |
+|841|./src/DocumentFormat.OpenXml/Packaging/ImagePartType.cs|Defines ImagePartType - types of ImagePart.| |
+|842|./src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPart.cs|Defines MailMergeRecipientDataPart.| |
+|843|./src/DocumentFormat.OpenXml/Packaging/MailMergeRecipientDataPartType.cs|Defines MailMergeRecipientDataPartType - types of MailMergeRecipientDataPart.| |
+|844|./src/DocumentFormat.OpenXml/Packaging/Model3DReferenceRelationshipPart.cs|Defines the Model3DReferenceRelationshipPart| |
+|845|./src/DocumentFormat.OpenXml/Packaging/OpenXmlSupportedRelationshipExtensions.cs|Defines extensions for part relationships| |
+|846|./src/DocumentFormat.OpenXml/Packaging/PartConstraints.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|847|./src/DocumentFormat.OpenXml/Packaging/PresentationDocument.FlatOpc.cs|Defines PresentationDocument - an OpenXmlPackage represents a Presentation document| |
+|848|./src/DocumentFormat.OpenXml/Packaging/PresentationDocument.cs|Defines PresentationDocument - an OpenXmlPackage represents a Presentation document| |
+|849|./src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.FlatOpc.cs|Creates a new editable instance of SpreadsheetDocument from an <see cref="XDocument"/>| |
+|850|./src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocument.cs|Defines SpreadsheetDocument - an OpenXmlPackage represents a Spreadsheet document.| |
+|851|./src/DocumentFormat.OpenXml/Packaging/SpreadsheetDocumentExtensions.cs|A collection of extensions for <see cref="SpreadsheetDocument"/>| |
+|852|./src/DocumentFormat.OpenXml/Packaging/StylesPart.cs|Defines StylesPart. The StylesPart served as the base class of StylesWithEffectsPart and StyleDefinitionsPart.| |
+|853|./src/DocumentFormat.OpenXml/Packaging/ThumbnailPartType.cs|Defines ThumbnailPartType - types of ThumbnailPart.| |
+|854|./src/DocumentFormat.OpenXml/Packaging/TypedPackageFeatureCollection.cs|An implementation of <see cref="OpenXmlPackage"/> that provides strongly-typed services.| |
+|855|./src/DocumentFormat.OpenXml/Packaging/TypedPartFeatureCollection.cs|An implementation that is used to provide information for strongly typed <see cref="OpenXmlPart"/>.| |
+|856|./src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.FlatOpc.cs|Defines WordprocessingDocument - an OpenXmlPackage represents a Word document.| |
+|857|./src/DocumentFormat.OpenXml/Packaging/WordprocessingDocument.cs|Defines WordprocessingDocument - an OpenXmlPackage represents a Word document.| |
+|858|./src/DocumentFormat.OpenXml/PresentationDocumentPartReader.cs|Represents an implementation of <see cref="OpenXmlPartReader"/> that is aware of the strongly typed classes for a <see cref="PresentationDocument"/>.| |
+|859|./src/DocumentFormat.OpenXml/PresentationDocumentType.cs|Defines PresentationDocumentType - type of PresentationDocument.| |
+|860|./src/DocumentFormat.OpenXml/Properties/Properties.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|861|./src/DocumentFormat.OpenXml/Schema/AdditionalCharacteristics/AdditionalCharacteristicsInfo.cs|Defines AdditionalCharacteristics.| |
+|862|./src/DocumentFormat.OpenXml/Schema/Bibliography/Sources.cs|Defines Sources.| |
+|863|./src/DocumentFormat.OpenXml/Schema/InkML/Ink.cs|Defines Ink.| |
+|864|./src/DocumentFormat.OpenXml/Schema/Office/CustomUI/CustomUI.cs|Defines CustomUI.| |
+|865|./src/DocumentFormat.OpenXml/Schema/Office/Word/MailMergeRecipients.cs|Defines MailMergeRecipients.| |
+|866|./src/DocumentFormat.OpenXml/Schema/Presentation/CommentPropertiesExtension.cs|<para>Data for the Windows platform..</para>| |
+|867|./src/DocumentFormat.OpenXml/Schema/Spreadsheet/CellType.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|868|./src/DocumentFormat.OpenXml/Schema/Spreadsheet/CellValue.cs|This provides additional constructors than in the generated files.| |
+|869|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/ConditionalFormatStyle.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|870|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/CustomXmlElement.cs|Defines CustomXmlElement - the base class for the customXml elements.| |
+|871|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/Document.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|872|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/Indentation.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|873|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/Justification.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|874|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/Recipients.cs|Defines Recipients.| |
+|875|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/SdtElement.cs|Defines SdtElement - the base class for the sdt elements.| |
+|876|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/StylePaneSortMethods.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|877|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/Styles.cs|Defines Styles.| |
+|878|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/TabStop.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|879|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/TableJustification.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|880|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/TableLook.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|881|./src/DocumentFormat.OpenXml/Schema/Wordprocessing/TextDirection.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|882|./src/DocumentFormat.OpenXml/SpreadsheetDocumentPartReader.cs|Represents an implementation of <see cref="OpenXmlPartReader"/> that is aware of the strongly typed classes for a <see cref="SpreadsheetDocument"/>.| |
+|883|./src/DocumentFormat.OpenXml/SpreadsheetDocumentType.cs|Defines SpreadsheetDocumentType - type of SpreadsheetDocument.| |
+|884|./src/DocumentFormat.OpenXml/TypeForwards.cs|Copyright (c) Microsoft. All rights reserved.| |
+|885|./src/DocumentFormat.OpenXml/WordprocessingDocumentPartReader.cs|Represents an implementation of <see cref="OpenXmlPartReader"/> that is aware of the strongly typed classes for a <see cref="Wordprocessing"/>.| |
+|886|./src/DocumentFormat.OpenXml/WordprocessingDocumentType.cs|Defines WordprocessingDocumentType - type of WordprocessingDocument.| |
+|887|./src/common/System/Collections/Concurrent/ConcurrentDictionary.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|888|./src/common/System/Collections/Generic/IReadOnlyCollection.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|889|./src/common/System/Collections/Generic/IReadOnlyDictionary.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|890|./src/common/System/Diagnostics/CodeAnalysis/ExperimentalAttribute.cs|Indicates that an API is experimental and it may change in the future.| |
+|891|./src/common/System/Diagnostics/CodeAnalysis/NullableAttributes.cs|Specifies that null is allowed as an input even if the corresponding type disallows it.| |
+|892|./src/common/System/EnumExtensions.cs|Copyright (c) Microsoft. All rights reserved.| |
+|893|./src/common/System/FormattableString.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|894|./src/common/System/HashCode.cs|A helpful utility to generate hashcodes. This is in box in .NET Core 2.1 and .NET Standard 2.1 (and later versions)| |
+|895|./src/common/System/IO/StreamCopyExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|896|./src/common/System/IO/StreamReadExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|897|./src/common/System/Lazy{T}.cs|An implementation of Lazy{T} that is supported on .NET 3.5 and is always thread-safe.| |
+|898|./src/common/System/ObsoleteAttribute.cs|Copyright (c) Microsoft. All rights reserved.| |
+|899|./src/common/System/Reflection/TypeExtensions.cs|TypeInfo is used in the code base as .NET Standard requires it. However, .NET 4.0 and .NET 3.5 do not have this or other| |
+|900|./src/common/System/Runtime/CompilerServices/CallerMemberNameAttribute.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|901|./src/common/System/Runtime/CompilerServices/FormattableStringFactory.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|902|./src/common/System/Runtime/CompilerServices/IsExternalInit.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|903|./src/common/System/Span.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|904|./src/common/System/SpanExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|905|./src/common/System/Threading/CancellationToken.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|906|./src/common/System/Xml/Linq/XDocumentExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|907|./test/Common/CultureInfoTester.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|908|./test/Common/VerifiableLog.cs|Start logical group in "script" category.| |
+|909|./test/DocumentFormat.OpenXml.Benchmarks/BuilderBenchmarks.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|910|./test/DocumentFormat.OpenXml.Benchmarks/Documents.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|911|./test/DocumentFormat.OpenXml.Benchmarks/ElementMetadataTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|912|./test/DocumentFormat.OpenXml.Benchmarks/ElementTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|913|./test/DocumentFormat.OpenXml.Benchmarks/EqualityBenchmark.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|914|./test/DocumentFormat.OpenXml.Benchmarks/NonwritingStream.cs|An implementation of stream that can be used for writing that will not allocate and will cause minimal performance| |
+|915|./test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementAddNamespaceDeclarationTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|916|./test/DocumentFormat.OpenXml.Benchmarks/OpenXmlElementDescendantsTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|917|./test/DocumentFormat.OpenXml.Benchmarks/Program.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|918|./test/DocumentFormat.OpenXml.Benchmarks/ValidationTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|919|./test/DocumentFormat.OpenXml.Framework.Features.Tests/RandomParagraphIdGeneratorTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|920|./test/DocumentFormat.OpenXml.Framework.Features.Tests/SharedParagraphIdGeneratorTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|921|./test/DocumentFormat.OpenXml.Framework.Features.Tests/TestFeatureCollection.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|922|./test/DocumentFormat.OpenXml.Framework.Tests/Builder/OpenXmlPackageBuilderTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|923|./test/DocumentFormat.OpenXml.Framework.Tests/ElementLookupTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|924|./test/DocumentFormat.OpenXml.Framework.Tests/Features/FeaturesInOpenXmlPartContainerTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|925|./test/DocumentFormat.OpenXml.Framework.Tests/Features/FeaturesTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|926|./test/DocumentFormat.OpenXml.Framework.Tests/Features/FilePackageFeatureTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|927|./test/DocumentFormat.OpenXml.Framework.Tests/Features/PackageEventsTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|928|./test/DocumentFormat.OpenXml.Framework.Tests/Features/PackageUriHandlingTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|929|./test/DocumentFormat.OpenXml.Framework.Tests/Features/SaveablePackageTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|930|./test/DocumentFormat.OpenXml.Framework.Tests/Features/StreamPackageFeatureTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|931|./test/DocumentFormat.OpenXml.Framework.Tests/HashCodeTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|932|./test/DocumentFormat.OpenXml.Framework.Tests/ITestOutputHelperExtenstions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|933|./test/DocumentFormat.OpenXml.Framework.Tests/IsExternalInit.cs|Copyright (c) Microsoft. All rights reserved.| |
+|934|./test/DocumentFormat.OpenXml.Framework.Tests/ObjectSizeTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|935|./test/DocumentFormat.OpenXml.Framework.Tests/OpenXmlNamespaceTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|936|./test/DocumentFormat.OpenXml.Framework.Tests/OpenXmlPartTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|937|./test/DocumentFormat.OpenXml.Framework.Tests/Particles/CompiledParticleTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|938|./test/DocumentFormat.OpenXml.Framework.Tests/Particles/TestOpenXmlCompositeElement.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|939|./test/DocumentFormat.OpenXml.Framework.Tests/PropertyBuilderTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|940|./test/DocumentFormat.OpenXml.Framework.Tests/ReadOnlyArrayTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|941|./test/DocumentFormat.OpenXml.Framework.Tests/TestUtility.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|942|./test/DocumentFormat.OpenXml.Framework.Tests/ValidatorAttributeTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|943|./test/DocumentFormat.OpenXml.Linq.Tests/OpenXmlPartRootXElementExtensionsTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|944|./test/DocumentFormat.OpenXml.Packaging.Tests/ITestOutputHelperExtenstions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|945|./test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPackageTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|946|./test/DocumentFormat.OpenXml.Packaging.Tests/OpenXmlPartReaderTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|947|./test/DocumentFormat.OpenXml.Packaging.Tests/PartConstraintRuleTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|948|./test/DocumentFormat.OpenXml.Packaging.Tests/PartExtensionProviderTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|949|./test/DocumentFormat.OpenXml.Packaging.Tests/PartUriHelperTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|950|./test/DocumentFormat.OpenXml.Packaging.Tests/ParticleTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|951|./test/DocumentFormat.OpenXml.Tests.Assets/IFile.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|952|./test/DocumentFormat.OpenXml.Tests.Assets/TemporaryFile.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|953|./test/DocumentFormat.OpenXml.Tests.Assets/TestAssets.TestDataStorage.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|954|./test/DocumentFormat.OpenXml.Tests.Assets/TestAssets.TestFiles.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|955|./test/DocumentFormat.OpenXml.Tests.Assets/TestAssets.cs|Open a file in memory for a test stream| |
+|956|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ChartTrackingRefBased/ChartTrackingRefBasedTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|957|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ChartTrackingRefBased/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|958|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ChartTrackingRefBased/TestEntities.cs|Gets or sets URI attribute value of PresentationPropertiesExtension| |
+|959|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/AppendCommentExIDs.cs|Element CommentEx in paraId attribute| |
+|960|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentAuthors.cs|Element Comment attribute "Author"| |
+|961|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentBodyStrings.cs|Word document body text| |
+|962|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentExTest.cs|Office15TCM: xxxxx: OASys#283293: OOXML SDK : COMPS : Invalid format on CommentEx| |
+|963|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentIDs.cs|Element Comment attribute "ID"| |
+|964|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentInitials.cs|Element Comment attribute "Initial"| |
+|965|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/CommentStrings.cs|Comment text| |
+|966|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/Commons.cs|Comment and CommentEx, Get support class.| |
+|967|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|968|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentEx/TestEntities.cs|Edit Comment and CommentEx| |
+|969|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentExPeople/CommentExPeopleTest.cs|Test for Comment People part.| |
+|970|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentExPeople/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|971|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/CommentExPeople/TestEntities.cs|Reading of People part element.| |
+|972|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/ContentControlTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|973|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/EditElement.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|974|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|975|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/RunStyleValues.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|976|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/TestColorValues.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|977|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/TestStrings.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|978|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/TestTagStrings.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|979|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ContentControl/VerifyElement.cs|To check whether a document has been changed correctly| |
+|980|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/FootnoteColumns/FootnoteColumnsTest.cs|Test for Footnote Column| |
+|981|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/FootnoteColumns/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|982|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/General/ConformanceTestBase.cs|Opens an existing document| |
+|983|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Guide/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|984|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Guide/GuideTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|985|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Guide/TestEntities.cs|Gets or sets URI attribute value of PresentationExtension.(Parent of P15.SlideGuideList element)| |
+|986|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/IGeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|987|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Pivot/ConnectionGeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|988|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Pivot/ConnectionTestEntities.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|989|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Pivot/PivotTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|990|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/PresetTransition/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|991|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/PresetTransition/PresetTransitionTest.cs|Document Read/Write Test for PresetTransition| |
+|992|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Slicer/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|993|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Slicer/SlicerTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|994|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Slicer/TestEntities.cs|Edit Slicer element| |
+|995|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Theme/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|996|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Theme/TestEntities.cs|Editing theme id attribute| |
+|997|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Theme/ThemeTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|998|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ThreadingInfo/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|999|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ThreadingInfo/TestEntities.cs|URI attribute value of PresentationExtension.(Parent of P15.ThreadingInfo element)| |
+|1000|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/ThreadingInfo/ThreadingInfoTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1001|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1002|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/TestEntities.cs|URI attribute value of PresentationExtension.(Parent of TimelineStyles element)| |
+|1003|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/Timeline/TimeLineTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1004|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/WebExtension/WebExtensionData.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1005|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/WebExtension/WebExtensionTest.cs|Walks the children of a Taskpanes element.| |
+|1006|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/WorkbookPr/GeneratedDocument.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1007|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/WorkbookPr/TestEntities.cs|Editing workbookPr element| |
+|1008|./test/DocumentFormat.OpenXml.Tests/ConformanceTest/WorkbookPr/WorkBookPrTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1009|./test/DocumentFormat.OpenXml.Tests/CreateFromTemplateTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1010|./test/DocumentFormat.OpenXml.Tests/Documents/DocumentTests.Autosave.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1011|./test/DocumentFormat.OpenXml.Tests/Documents/DocumentTests.FlatOpcTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1012|./test/DocumentFormat.OpenXml.Tests/Documents/DocumentTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1013|./test/DocumentFormat.OpenXml.Tests/Documents/FlatOpcAndCloningTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1014|./test/DocumentFormat.OpenXml.Tests/Documents/PresentationDocumentTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1015|./test/DocumentFormat.OpenXml.Tests/Documents/SpreadsheetDocumentTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1016|./test/DocumentFormat.OpenXml.Tests/Documents/WordprocessingDocumentTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1017|./test/DocumentFormat.OpenXml.Tests/DocxTests01.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1018|./test/DocumentFormat.OpenXml.Tests/Extensions/AttributeExtensions.cs|Get XName of pass-in OpenXmlAttribute.| |
+|1019|./test/DocumentFormat.OpenXml.Tests/Extensions/EnumerableExtensions.cs|<typeparam name="TSource">Type of collection content</typeparam>| |
+|1020|./test/DocumentFormat.OpenXml.Tests/Extensions/FileExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1021|./test/DocumentFormat.OpenXml.Tests/Extensions/OpenXmlElementExtensions.cs|<param name="e">current element</param>| |
+|1022|./test/DocumentFormat.OpenXml.Tests/Extensions/OpenXmlPartExtensions.cs|Check if current <paramref name="part"/> is main part of the package.| |
+|1023|./test/DocumentFormat.OpenXml.Tests/Extensions/TestPackageExtensions.cs|Get Main Part of current package| |
+|1024|./test/DocumentFormat.OpenXml.Tests/Extensions/XmlExtensions.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1025|./test/DocumentFormat.OpenXml.Tests/FileFormatVersionExtensionsTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1026|./test/DocumentFormat.OpenXml.Tests/GenCode01.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1027|./test/DocumentFormat.OpenXml.Tests/GeneratedClass001.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1028|./test/DocumentFormat.OpenXml.Tests/GeneratedClass002.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1029|./test/DocumentFormat.OpenXml.Tests/GeneratedClass003.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1030|./test/DocumentFormat.OpenXml.Tests/IsoStrictTest/IsoStrictTest.cs|Test for ISO Strict file format on Open XML SDK| |
+|1031|./test/DocumentFormat.OpenXml.Tests/MockedOpenXmlElement.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1032|./test/DocumentFormat.OpenXml.Tests/OFCatTest/Robustness.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1033|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/CodeGenSanityTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1034|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/DocumentOpenTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1035|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/DocumentTraverseTest.cs|Traversing up the specified Document Part using Parent, Ancestors(), and Ancestors&ltT&gt Methods| |
+|1036|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/GenerateList4LowLevelTest.cs|Generate list of type and associating (attribute/child element) properties for low-level testing.| |
+|1037|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/MarkupCompatibilityTest.cs|Summary description for MarkupCompatibilityTest| |
+|1038|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenSettingsTestClass.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1039|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlCompositeElementTestClass.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1040|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlDomTestBase.cs|The OpenXmlDom test framework. It contains help methods for testing OpenXmlDom Classes| |
+|1041|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlReaderWriterTest.cs|Summary description for OpenXmlReaderWriterTest| |
+|1042|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlRootElementTestClass.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1043|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlSimpleTypeTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1044|./test/DocumentFormat.OpenXml.Tests/OpenXmlDomTest/OpenXmlSimpleValueTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1045|./test/DocumentFormat.OpenXml.Tests/OpenXmlElementContextTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1046|./test/DocumentFormat.OpenXml.Tests/OpenXmlElementEqualityTest.cs|Test that shows extended attributes are considered in equality.| |
+|1047|./test/DocumentFormat.OpenXml.Tests/OpenXmlElementFunctionalExtensionsTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1048|./test/DocumentFormat.OpenXml.Tests/OpenXmlElementParsingTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1049|./test/DocumentFormat.OpenXml.Tests/OpenXmlPartTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1050|./test/DocumentFormat.OpenXml.Tests/OpenXmlTestBase.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1051|./test/DocumentFormat.OpenXml.Tests/PackageAssert.cs|Asserts that two OpenXmlPackage instances have the same content.| |
+|1052|./test/DocumentFormat.OpenXml.Tests/PptxTests01.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1053|./test/DocumentFormat.OpenXml.Tests/SaveAndCloneTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1054|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/Base64BinaryValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1055|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/BooleanValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1056|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/ByteValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1057|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/DateTimeValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1058|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/DecimalValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1059|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/DoubleValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1060|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/HexBinaryValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1061|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/Int16ValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1062|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/Int32ValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1063|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/Int64ValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1064|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/IntegerValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1065|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/OnOffValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1066|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/OpenXmlComparableSimpleReferenceTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1067|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/OpenXmlComparableSimpleValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1068|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/SByteValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1069|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/SingleValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1070|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/StringValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1071|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/TrueFalseBlankValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1072|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/TrueFalseValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1073|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/UInt16ValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1074|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/UInt32ValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1075|./test/DocumentFormat.OpenXml.Tests/SimpleTypes/UInt64ValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1076|./test/DocumentFormat.OpenXml.Tests/Spreadsheet/CellTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1077|./test/DocumentFormat.OpenXml.Tests/Spreadsheet/CellValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1078|./test/DocumentFormat.OpenXml.Tests/TestOffice2016.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1079|./test/DocumentFormat.OpenXml.Tests/Validation/ReferenceReleaseTests.cs|The OpenXmlValidator caches some items, and at one point cached the documents themselves which we do not want them to do| |
+|1080|./test/DocumentFormat.OpenXml.Tests/Validation/Schema/Restrictions/TokenRestrictionTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1081|./test/DocumentFormat.OpenXml.Tests/Validation/Semantic/AttributeRequiredConditionToValueTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1082|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/ConditionalFormatStyleTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1083|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/DocumentTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1084|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/IndentationTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1085|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/JustificationTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1086|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/StylePaneSortMethodsTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1087|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/TabStopTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1088|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/TableJustificationTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1089|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/TableLookTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1090|./test/DocumentFormat.OpenXml.Tests/Wordprocessing/TextDirectionTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1091|./test/DocumentFormat.OpenXml.Tests/XlsxTests01.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1092|./test/DocumentFormat.OpenXml.Tests/XmlConvertingReaderTests.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1093|./test/DocumentFormat.OpenXml.Tests/ofapiTest/AllParticleValidatorTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1094|./test/DocumentFormat.OpenXml.Tests/ofapiTest/AnyParticleValidatorTest.cs|This is a test class for AnyParticleValidatorTest and is intended| |
+|1095|./test/DocumentFormat.OpenXml.Tests/ofapiTest/BugRegressionTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1096|./test/DocumentFormat.OpenXml.Tests/ofapiTest/ChoiceParticleValidatorTest.cs|This is a test class for ChoiceParticleValidatorTest and is intended| |
+|1097|./test/DocumentFormat.OpenXml.Tests/ofapiTest/CompositeParticleValidatorTest.cs|This is a test class for CompositeParticleValidatorTest and is intended| |
+|1098|./test/DocumentFormat.OpenXml.Tests/ofapiTest/CustomXmlElementTest.cs|CustomXmlElementTests.| |
+|1099|./test/DocumentFormat.OpenXml.Tests/ofapiTest/DocumentValidatorTests.cs|This is a test class for SchemaValidatorTest and is intended| |
+|1100|./test/DocumentFormat.OpenXml.Tests/ofapiTest/GroupParticleValidatorTest.cs|This is a test class for GroupParticleValidatorTest and is intended| |
+|1101|./test/DocumentFormat.OpenXml.Tests/ofapiTest/ListValueTest.cs|This is a test class for ListValueTest and is intended| |
+|1102|./test/DocumentFormat.OpenXml.Tests/ofapiTest/M4Conformance.cs|O14OnlyElesInO12.| |
+|1103|./test/DocumentFormat.OpenXml.Tests/ofapiTest/MCSupport.cs|Load MC attribute| |
+|1104|./test/DocumentFormat.OpenXml.Tests/ofapiTest/McValidationTest.cs|Summary description for McValidationTest| |
+|1105|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlCompositeElementTest.cs|This is a test class for OpenXmlCompositeElementTest and is intended| |
+|1106|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest.cs|This is a test class for OpenXmlElementTest and is intended| |
+|1107|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlElementTest2.cs|TestGetPartRootElement.| |
+|1108|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlPackageTest.cs|Summary description for OpenXmlPackageTest| |
+|1109|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlPartTest.cs|This is a test class for OpenXmlPartTest and is intended| |
+|1110|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlReaderTest.cs|This is a test class for OpenXmlReaderTest and is intended| |
+|1111|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlSimpleValueTest2.cs|This is a test class for BooleanValueTest and is intended| |
+|1112|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlValidatorTest.cs|A test for Validate(element) - validating boolean attribute.| |
+|1113|./test/DocumentFormat.OpenXml.Tests/ofapiTest/OpenXmlWriterTest.cs|This is a test class for OpenXmlPartWriterTest and is intended| |
+|1114|./test/DocumentFormat.OpenXml.Tests/ofapiTest/SemanticConstraintTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |
+|1115|./test/DocumentFormat.OpenXml.Tests/ofapiTest/SemanticValidationTest.cs|SemanticValidationTest| |
+|1116|./test/DocumentFormat.OpenXml.Tests/ofapiTest/SequenceParticleValidatorTest.cs|This is a test class for SequenceParticleValidatorTest and is intended| |
+|1117|./test/DocumentFormat.OpenXml.Tests/ofapiTest/UnknownElementTests.cs|A test for the OpenXmlUnknownElement.CreateOpenXmlUnknownElement with an outer xml.| |
+|1118|./test/DocumentFormat.OpenXml.Tests/ofapiTest/ValidationErrorStrings.cs|="List of possible elements expected:"| |
+|1119|./test/DocumentFormat.OpenXml.Tests/ofapiTest/ValidatorCancellationExtensions.cs|Used for tests that cross compile and need to pass in a cancellation token. Since this is shadowed currently in the .NET 3.5 builds,| |
+|1120|./test/DocumentFormat.OpenXml.Tests/ofapiTest/ValidatorExtension.cs|Validate the DOM tree under the specified OpenXmlElement.| |
+|1121|./test/DocumentFormat.OpenXml.Tests/ofapiTest/XmlPathTest.cs|Licensed under the MIT license. See LICENSE file in the project root for full license information.| |


### PR DESCRIPTION
## Summary
- add a generated table listing all C# source files for tracking Java conversion

## Testing
- `dotnet test --no-restore` *(fails: `dotnet: command not found`)*